### PR TITLE
Tuple Recognizer bug fixes

### DIFF
--- a/api/swim_form/src/structural/read/recognizer/mod.rs
+++ b/api/swim_form/src/structural/read/recognizer/mod.rs
@@ -809,6 +809,7 @@ impl<T, Flds> Recognizer for OrdinalFieldsRecognizer<T, Flds> {
         } else if *index == *num_fields {
             Some(Err(ReadError::UnexpectedItem))
         } else {
+            *state = BodyStage::Item;
             let r = select_recog(fields, *index, input)?;
             if let Err(e) = r {
                 Some(Err(e))
@@ -2473,7 +2474,7 @@ macro_rules! impl_readable_tuple {
                             match result {
                                 Ok(v) => {
                                     *$vname = Some(v);
-                                    None
+                                    Some(Ok(()))
                                 },
                                 Err(e) => {
                                     Some(Err(e))

--- a/api/swim_form/src/tests/impls.rs
+++ b/api/swim_form/src/tests/impls.rs
@@ -129,7 +129,6 @@ mod primitive {
 }
 
 mod collections {
-
     use super::*;
 
     #[test]
@@ -249,4 +248,278 @@ fn test_map_modification() {
         result2,
         Ok(FormMapUpdate::Update(Value::text("hello"), body))
     );
+}
+
+mod tuples {
+    use super::*;
+
+    #[test]
+    fn test_tuple_1() {
+        let value = (0,).as_value();
+        assert_eq!(value, expected_tuple(1));
+        assert_eq!(<(i32,)>::try_from_value(&value), Ok((0,)));
+    }
+
+    #[test]
+    fn test_tuple_2() {
+        let value = (0, 1).as_value();
+        assert_eq!(value, expected_tuple(2));
+        assert_eq!(<(i32, i32)>::try_from_value(&value), Ok((0, 1)));
+    }
+
+    #[test]
+    fn test_tuple_3() {
+        let value = (0, 1, 2).as_value();
+        assert_eq!(value, expected_tuple(3));
+        assert_eq!(<(i32, i32, i32)>::try_from_value(&value), Ok((0, 1, 2)));
+    }
+
+    #[test]
+    fn test_tuple_4() {
+        let value = (0, 1, 2, 3).as_value();
+        assert_eq!(value, expected_tuple(4));
+        assert_eq!(
+            <(i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn test_tuple_5() {
+        let value = (0, 1, 2, 3, 4).as_value();
+        assert_eq!(value, expected_tuple(5));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4))
+        );
+    }
+
+    #[test]
+    fn test_tuple_6() {
+        let value = (0, 1, 2, 3, 4, 5).as_value();
+        assert_eq!(value, expected_tuple(6));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5))
+        );
+    }
+
+    #[test]
+    fn test_tuple_7() {
+        let value = (0, 1, 2, 3, 4, 5, 6).as_value();
+        assert_eq!(value, expected_tuple(7));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6))
+        );
+    }
+
+    #[test]
+    fn test_tuple_8() {
+        let value = (0, 1, 2, 3, 4, 5, 6, 7).as_value();
+        assert_eq!(value, expected_tuple(8));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6, 7))
+        );
+    }
+
+    #[test]
+    fn test_tuple_9() {
+        let value = (0, 1, 2, 3, 4, 5, 6, 7, 8).as_value();
+        assert_eq!(value, expected_tuple(9));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6, 7, 8))
+        );
+    }
+
+    #[test]
+    fn test_tuple_10() {
+        let value = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9).as_value();
+        assert_eq!(value, expected_tuple(10));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+        );
+    }
+
+    #[test]
+    fn test_tuple_11() {
+        let value = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).as_value();
+        assert_eq!(value, expected_tuple(11));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        );
+    }
+
+    #[test]
+    fn test_tuple_12() {
+        let value = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).as_value();
+        assert_eq!(value, expected_tuple(12));
+        assert_eq!(
+            <(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>::try_from_value(&value),
+            Ok((0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+        );
+    }
+
+    #[derive(Form, Debug, Eq, PartialEq)]
+    struct Foo {
+        a: usize,
+        b: usize,
+    }
+
+    #[test]
+    fn tuple_with_struct() {
+        let value = (1, Foo { a: 10, b: 20 }).as_value();
+        assert_eq!(
+            value,
+            Value::Record(vec![], vec![Item::from(1), expected_struct()])
+        );
+        assert_eq!(
+            <(i32, Foo)>::try_from_value(&value),
+            Ok((1, Foo { a: 10, b: 20 }))
+        );
+
+        let value = (Foo { a: 10, b: 20 }, 2, 3).as_value();
+        assert_eq!(
+            value,
+            Value::Record(
+                vec![],
+                vec![expected_struct(), Item::from(2), Item::from(3)],
+            )
+        );
+        assert_eq!(
+            <(Foo, i32, i32)>::try_from_value(&value),
+            Ok((Foo { a: 10, b: 20 }, 2, 3))
+        );
+
+        let value = (
+            Foo { a: 10, b: 20 },
+            Foo { a: 10, b: 20 },
+            Foo { a: 10, b: 20 },
+        )
+            .as_value();
+        assert_eq!(
+            value,
+            Value::Record(
+                vec![],
+                vec![expected_struct(), expected_struct(), expected_struct()],
+            )
+        );
+        assert_eq!(
+            <(Foo, Foo, Foo)>::try_from_value(&value),
+            Ok((
+                Foo { a: 10, b: 20 },
+                Foo { a: 10, b: 20 },
+                Foo { a: 10, b: 20 }
+            ))
+        );
+    }
+
+    #[derive(Form, Debug, Eq, PartialEq)]
+    enum Bar {
+        A(usize),
+        B { a: usize, b: usize },
+        C,
+    }
+
+    #[test]
+    fn tuple_with_enum() {
+        let value = (1, Bar::A(10)).as_value();
+        assert_eq!(
+            value,
+            Value::Record(vec![], vec![Item::from(1), expected_enum(1)])
+        );
+        assert_eq!(<(i32, Bar)>::try_from_value(&value), Ok((1, Bar::A(10))));
+
+        let value = (1, Bar::B { a: 10, b: 20 }).as_value();
+        assert_eq!(
+            value,
+            Value::Record(vec![], vec![Item::from(1), expected_enum(2)])
+        );
+        assert_eq!(
+            <(i32, Bar)>::try_from_value(&value),
+            Ok((1, Bar::B { a: 10, b: 20 }))
+        );
+
+        let value = (1, Bar::C).as_value();
+        assert_eq!(
+            value,
+            Value::Record(vec![], vec![Item::from(1), expected_enum(3)])
+        );
+        assert_eq!(<(i32, Bar)>::try_from_value(&value), Ok((1, Bar::C)));
+
+        let value = (Bar::A(10), Bar::B { a: 10, b: 20 }, Bar::C).as_value();
+        assert_eq!(
+            value,
+            Value::Record(
+                vec![],
+                vec![expected_enum(1), expected_enum(2), expected_enum(3)]
+            )
+        );
+        assert_eq!(
+            <(Bar, Bar, Bar)>::try_from_value(&value),
+            Ok((Bar::A(10), Bar::B { a: 10, b: 20 }, Bar::C))
+        );
+    }
+
+    #[test]
+    fn tuple_with_both() {
+        let value = (1, Foo { a: 10, b: 20 }, 2, Bar::A(10), 3).as_value();
+        assert_eq!(
+            value,
+            Value::Record(
+                vec![],
+                vec![
+                    Item::from(1),
+                    expected_struct(),
+                    Item::from(2),
+                    expected_enum(1),
+                    Item::from(3)
+                ]
+            )
+        );
+        assert_eq!(
+            <(i32, Foo, i32, Bar, i32)>::try_from_value(&value),
+            Ok((1, Foo { a: 10, b: 20 }, 2, Bar::A(10), 3))
+        );
+    }
+
+    fn expected_tuple(size: i32) -> Value {
+        let mut items = vec![];
+        for i in 0..size {
+            items.push(Item::of(Value::Int32Value(i)));
+        }
+        Value::record(items)
+    }
+
+    fn expected_struct() -> Item {
+        Item::from(Value::Record(
+            vec![Attr::from("Foo")],
+            vec![
+                Item::from(("a", Value::UInt64Value(10))),
+                Item::from(("b", Value::UInt64Value(20))),
+            ],
+        ))
+    }
+
+    fn expected_enum(variant: usize) -> Item {
+        match variant {
+            1 => Item::from(Value::Record(
+                vec![Attr::from("A")],
+                vec![Item::from(Value::UInt64Value(10))],
+            )),
+            2 => Item::from(Value::Record(
+                vec![Attr::from("B")],
+                vec![
+                    Item::from(("a", Value::UInt64Value(10))),
+                    Item::from(("b", Value::UInt64Value(20))),
+                ],
+            )),
+            3 => Item::from(Value::Record(vec![Attr::from("C")], vec![])),
+            _ => unreachable!(),
+        }
+    }
 }


### PR DESCRIPTION
Fixes:
1) Recognizer for tuples always failing.
2) Recognizer for tuples failing on complex types (structs, enums).