### PR TITLE
Recon header peeler.

### DIFF
--- a/api/formats/swim_recon/Cargo.toml
+++ b/api/formats/swim_recon/Cargo.toml
@@ -26,4 +26,3 @@ thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.1.1", features = ["io-util", "macros", "rt", "fs"] }
-bytes = "1.0"

--- a/api/formats/swim_recon/Cargo.toml
+++ b/api/formats/swim_recon/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.1.1", features = ["io-util"], optional = true }
 tokio-util = { version = "0.6.8", optional = true, features = ["codec"] }
 bytes = { version = "^1.0.0", optional = true }
 smallvec ="1.7.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.1.1", features = ["io-util", "macros", "rt", "fs"] }

--- a/api/formats/swim_recon/Cargo.toml
+++ b/api/formats/swim_recon/Cargo.toml
@@ -26,3 +26,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.1.1", features = ["io-util", "macros", "rt", "fs"] }
+bytes = "1.0"

--- a/api/formats/swim_recon/src/parser/mod.rs
+++ b/api/formats/swim_recon/src/parser/mod.rs
@@ -30,6 +30,8 @@ use swim_form::structural::read::recognizer::{Recognizer, RecognizerReadable};
 use swim_form::structural::read::ReadError;
 use swim_model::Value;
 
+pub use record::matcher;
+
 /// Wraps a string in a structure that keeps track of the line and column
 /// as the input is parsed.
 pub type Span<'a> = LocatedSpan<&'a str>;

--- a/api/formats/swim_recon/src/parser/mod.rs
+++ b/api/formats/swim_recon/src/parser/mod.rs
@@ -30,7 +30,7 @@ use swim_form::structural::read::recognizer::{Recognizer, RecognizerReadable};
 use swim_form::structural::read::ReadError;
 use swim_model::Value;
 
-pub use record::matcher::{HeaderPeeler, peel_message};
+pub use record::matcher::{try_extract_header, HeaderPeeler, MessageExtractError};
 
 /// Wraps a string in a structure that keeps track of the line and column
 /// as the input is parsed.

--- a/api/formats/swim_recon/src/parser/mod.rs
+++ b/api/formats/swim_recon/src/parser/mod.rs
@@ -30,7 +30,7 @@ use swim_form::structural::read::recognizer::{Recognizer, RecognizerReadable};
 use swim_form::structural::read::ReadError;
 use swim_model::Value;
 
-pub use record::matcher;
+pub use record::matcher::{HeaderPeeler, peel_message};
 
 /// Wraps a string in a structure that keeps track of the line and column
 /// as the input is parsed.

--- a/api/formats/swim_recon/src/parser/record/matcher/mod.rs
+++ b/api/formats/swim_recon/src/parser/record/matcher/mod.rs
@@ -44,15 +44,15 @@ pub trait HeaderPeeler<'a>: Clone {
     /// Provide the name of the tag attribute.
     ///
     /// #Arguments
-    /// * `name` - The name of the tag. Not that this has a more restrictive lifetime as may
-    /// have been unescaped buy the parser.
+    /// * `name` - The name of the tag. Note that this has a more restrictive lifetime as may
+    /// have been unescaped by the parser.
     fn tag(self, name: &str) -> Result<Self, Self::Error>;
 
     /// Feed a slot from the body of the attribute.
     ///
     /// #Arguments
-    /// * `name` - The name of the slot. Not that this has a more restrictive lifetime as may
-    /// have been unescaped buy the parser.
+    /// * `name` - The name of the slot. Note that this has a more restrictive lifetime as may
+    /// have been unescaped by the parser.
     /// * `value` - Span of the input containing the Recon of the value of the slot.
     fn feed_header_slot(self, name: &str, value: Span<'a>) -> Result<Self, Self::Error>;
 
@@ -70,7 +70,7 @@ pub trait HeaderPeeler<'a>: Clone {
     ///
     /// #Arguments
     /// * `body` - The remainder of the input span. Note that this is entirely uninterpreted and
-    /// so many not contain valid Recon.
+    /// so may not contain valid Recon.
     fn done(self, body: Span<'a>) -> Result<Self::Output, Self::Error>;
 }
 

--- a/api/formats/swim_recon/src/parser/record/matcher/mod.rs
+++ b/api/formats/swim_recon/src/parser/record/matcher/mod.rs
@@ -210,7 +210,7 @@ where
     }
 }
 
-pub fn peel_items<'a, P>(peeler: P) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, P>
+fn peel_items<'a, P>(peeler: P) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, P>
 where
     P: HeaderPeeler<'a>,
 {

--- a/api/formats/swim_recon/src/parser/record/matcher/mod.rs
+++ b/api/formats/swim_recon/src/parser/record/matcher/mod.rs
@@ -1,0 +1,252 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+
+use super::super::tokens::complete::{blob, identifier, numeric_literal};
+use super::super::tokens::string_literal;
+use super::attr_name;
+use nom::branch::alt;
+use nom::character::complete::{char, multispace0, one_of, space0};
+use nom::combinator::{flat_map, map, map_res, opt, recognize, rest};
+use nom::multi::{fold_many0, many0_count, many1_count};
+use nom::sequence::{delimited, pair, preceded, terminated, tuple};
+use nom::IResult;
+
+use crate::parser::Span;
+
+pub trait HeaderPeeler<'a>: Clone {
+    type Output: 'a;
+    type Error: Clone + 'a;
+
+    fn tag(self, name: &str) -> Result<Self, Self::Error>;
+
+    fn feed_header_slot(self, name: &str, value: Span<'a>) -> Result<Self, Self::Error>;
+
+    fn feed_header_value(self, value: Span<'a>) -> Result<Self, Self::Error>;
+
+    fn feed_header_extant(self) -> Result<Self, Self::Error>;
+
+    fn done(self, body: Span<'a>) -> Result<Self::Output, Self::Error>;
+}
+
+pub fn peel_message<P>(
+    peeler: P,
+) -> impl for<'a> FnMut(Span<'a>) -> IResult<Span<'a>, <P as HeaderPeeler<'a>>::Output>
+where
+    P: for<'a> HeaderPeeler<'a>,
+{
+    move |input| {
+        map_res(pair(peel_tag_attr(peeler.clone()), rest), |(p, rem)| {
+            p.done(rem)
+        })(input)
+    }
+}
+
+fn value<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    alt((
+        recognize(string_literal),
+        recognize(identifier),
+        recognize(numeric_literal),
+        recognize(blob),
+        record,
+    ))(input)
+}
+
+fn record<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    alt((recognize(pair(attrs, body_after_attrs)), standalone_body))(input)
+}
+
+fn attrs<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(many1_count(pair(attr, space0)))(input)
+}
+
+fn attr<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(tuple((char('@'), attr_name, opt(attr_body))))(input)
+}
+
+fn attr_body<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    delimited(
+        pair(char('('), multispace0),
+        items,
+        pair(multispace0, char(')')),
+    )(input)
+}
+
+fn items<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(pair(opt(item), many0_count(preceded(separator, opt(item)))))(input)
+}
+
+fn separator<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(delimited(space0, one_of(",;\n\r"), multispace0))(input)
+}
+
+fn slot_div<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(delimited(multispace0, char(':'), multispace0))(input)
+}
+
+fn item<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(pair(value, opt(preceded(slot_div, opt(value)))))(input)
+}
+
+fn body_after_attrs<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    recognize(opt(alt((
+        recognize(string_literal),
+        recognize(identifier),
+        recognize(numeric_literal),
+        recognize(blob),
+        standalone_body,
+    ))))(input)
+}
+
+fn standalone_body<'a>(input: Span<'a>) -> IResult<Span<'a>, Span<'a>> {
+    delimited(char('{'), items, char('}'))(input)
+}
+
+fn name<'a>(input: Span<'a>) -> IResult<Span<'a>, Cow<'a, str>> {
+    alt((map(identifier, Cow::Borrowed), string_literal))(input)
+}
+
+fn match_tag<P>(peeler: P) -> impl for<'a> FnMut(Span<'a>) -> IResult<Span<'a>, P>
+where
+    P: for<'a> HeaderPeeler<'a>,
+{
+    move |input| {
+        map_res(preceded(char('@'), name), |tag| {
+            let p = peeler.clone();
+            p.tag(&tag)
+        })(input)
+    }
+}
+
+enum PeelItem<'a> {
+    ValueItem(Span<'a>),
+    SlotItem(Cow<'a, str>, Span<'a>),
+}
+
+fn peel_value_item<'a>(input: Span<'a>) -> IResult<Span<'a>, PeelItem<'a>> {
+    map(recognize(value), PeelItem::ValueItem)(input)
+}
+
+fn peel_slot_item<'a>(input: Span<'a>) -> IResult<Span<'a>, PeelItem<'a>> {
+    map(
+        pair(name, preceded(slot_div, recognize(opt(value)))),
+        |(name, v)| PeelItem::SlotItem(name, v),
+    )(input)
+}
+
+fn peel_item<'a>(input: Span<'a>) -> IResult<Span<'a>, PeelItem<'a>> {
+    alt((peel_slot_item, peel_value_item))(input)
+}
+
+struct SepPeelItem<'a> {
+    item: Option<PeelItem<'a>>,
+    after_sep: bool,
+}
+
+impl<'a> SepPeelItem<'a> {
+    fn new(item: Option<PeelItem<'a>>, after_sep: bool) -> Self {
+        SepPeelItem { item, after_sep }
+    }
+}
+
+fn peel_item_with_sep<'a>(input: Span<'a>) -> IResult<Span<'a>, SepPeelItem<'a>> {
+    alt((
+        map(
+            terminated(opt(peel_item), pair(space0, one_of(",;"))),
+            |item| SepPeelItem::new(item, true),
+        ),
+        map(
+            terminated(peel_item, pair(space0, one_of("\r\n"))),
+            |item| SepPeelItem::new(Some(item), false),
+        ),
+    ))(input)
+}
+
+fn peel_final_item<P>(
+    peeler: P,
+    terminated: bool,
+) -> impl for<'a> FnMut(Span<'a>) -> IResult<Span<'a>, P>
+where
+    P: for<'a> HeaderPeeler<'a>,
+{
+    move |input| {
+        let peeler_ref = &peeler;
+        map_res(opt(peel_item), move |maybe| {
+            let p = (*peeler_ref).clone();
+            if let Some(item) = maybe {
+                apply_item(p, item)
+            } else if terminated {
+                p.feed_header_extant()
+            } else {
+                Ok(p)
+            }
+        })(input)
+    }
+}
+
+pub fn peel_items<P>(peeler: P) -> impl for<'a> FnMut(Span<'a>) -> IResult<Span<'a>, P>
+where
+    P: for<'a> HeaderPeeler<'a>,
+{
+    move |input| {
+        let peeler_ref = &peeler;
+        let sequence_with_res = fold_many0(
+            peel_item_with_sep,
+            move || (Ok((*peeler_ref).clone()), true),
+            |(p, _), item| {
+                let SepPeelItem { item, after_sep } = item;
+                let updated = p.and_then(move |peeler| {
+                    if let Some(item) = item {
+                        apply_item(peeler, item)
+                    } else {
+                        peeler.feed_header_extant()
+                    }
+                });
+                (updated, after_sep)
+            },
+        );
+
+        let sequence = map_res(sequence_with_res, |(r, after_sep)| {
+            r.map(|p| (p, after_sep))
+        });
+
+        delimited(
+            multispace0,
+            flat_map(sequence, |(p, after_sep)| peel_final_item(p, after_sep)),
+            multispace0,
+        )(input)
+    }
+}
+
+fn apply_item<'a, P>(peeler: P, item: PeelItem<'a>) -> Result<P, P::Error>
+where
+    P: HeaderPeeler<'a>,
+{
+    match item {
+        PeelItem::ValueItem(v) => peeler.feed_header_value(v),
+        PeelItem::SlotItem(name, v) => peeler.feed_header_slot(&name, v),
+    }
+}
+
+fn peel_tag_attr<P>(peeler: P) -> impl for<'a> FnMut(Span<'a>) -> IResult<Span<'a>, P>
+where
+    P: for<'a> HeaderPeeler<'a>,
+{
+    move |input| {
+        flat_map(match_tag(peeler.clone()), |p| {
+            delimited(char('('), peel_items(p), char(')'))
+        })(input)
+    }
+}

--- a/api/formats/swim_recon/src/parser/record/matcher/tests.rs
+++ b/api/formats/swim_recon/src/parser/record/matcher/tests.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nom::sequence::{delimited, preceded};
 use nom::character::complete::multispace0;
 use nom::combinator::eof;
+use nom::sequence::{delimited, preceded};
 
 use nom::IResult;
 
@@ -22,12 +22,12 @@ use crate::parser::Span;
 
 use super::HeaderPeeler;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct TestPeeler<'a> {
     name: Option<String>,
-    slots: Vec<(String, Span<'a>)>,
-    values: Vec<Option<Span<'a>>>,
-    body: Option<Span<'a>>,
+    slots: Vec<(String, &'a str)>,
+    values: Vec<Option<&'a str>>,
+    body: Option<&'a str>,
 }
 
 #[derive(Clone)]
@@ -50,13 +50,13 @@ impl<'a> HeaderPeeler<'a> for TestPeeler<'a> {
 
     fn feed_header_slot(mut self, name: &str, value: Span<'a>) -> Result<Self, Self::Error> {
         let TestPeeler { slots, .. } = &mut self;
-        slots.push((name.to_string(), value));
+        slots.push((name.to_string(), *value));
         Ok(self)
     }
 
     fn feed_header_value(mut self, value: Span<'a>) -> Result<Self, Self::Error> {
         let TestPeeler { values, .. } = &mut self;
-        values.push(Some(value));
+        values.push(Some(*value));
         Ok(self)
     }
 
@@ -71,7 +71,7 @@ impl<'a> HeaderPeeler<'a> for TestPeeler<'a> {
         if body.is_some() {
             Err(Inconsistent)
         } else {
-            *body = Some(body_span);
+            *body = Some(*body_span);
             Ok(self)
         }
     }
@@ -140,4 +140,282 @@ fn recognize_values() {
             panic!("Parse failed.");
         }
     }
+}
+
+#[test]
+fn peel_tag() {
+    let msg = Span::new("@attr");
+    let result = super::peel_message(TestPeeler::default())(msg);
+    assert!(result.is_ok());
+    let (
+        _,
+        TestPeeler {
+            name,
+            slots,
+            values,
+            body,
+        },
+    ) = result.unwrap();
+
+    assert_eq!(name, Some("attr".to_string()));
+    assert!(slots.is_empty());
+    assert!(values.is_empty());
+    assert_eq!(body, Some(""));
+}
+
+#[test]
+fn peel_tag_empty_body() {
+    let msg = Span::new("@attr()");
+    let result = super::peel_message(TestPeeler::default())(msg);
+
+    assert!(result.is_ok());
+    let (
+        _,
+        TestPeeler {
+            name,
+            slots,
+            values,
+            body,
+        },
+    ) = result.unwrap();
+
+    assert_eq!(name, Some("attr".to_string()));
+    assert!(slots.is_empty());
+    assert_eq!(values, vec![None]);
+    assert_eq!(body, Some(""));
+}
+
+#[test]
+fn peel_tag_simple_body() {
+    let msg = Span::new("@attr(5)");
+    let result = super::peel_message(TestPeeler::default())(msg);
+
+    assert!(result.is_ok());
+    let (
+        _,
+        TestPeeler {
+            name,
+            slots,
+            values,
+            body,
+        },
+    ) = result.unwrap();
+
+    assert_eq!(name, Some("attr".to_string()));
+    assert!(slots.is_empty());
+
+    assert_eq!(values, vec![Some("5")]);
+    assert_eq!(body, Some(""));
+}
+
+#[test]
+fn peel_tag_several_value_items() {
+    let check = |msg, expected| {
+        let result = super::peel_message(TestPeeler::default())(msg);
+
+        assert!(result.is_ok());
+        let (
+            _,
+            TestPeeler {
+                name,
+                slots,
+                values,
+                body,
+            },
+        ) = result.unwrap();
+
+        assert_eq!(name, Some("attr".to_string()));
+        assert!(slots.is_empty());
+
+        assert_eq!(values, expected);
+        assert_eq!(body, Some(""));
+    };
+
+    check(
+        Span::new("@attr(1,2,3)"),
+        vec![Some("1"), Some("2"), Some("3")],
+    );
+    check(
+        Span::new("@attr( 1, 2, 3 )"),
+        vec![Some("1"), Some("2"), Some("3")],
+    );
+    check(
+        Span::new("@attr(1;2;3)"),
+        vec![Some("1"), Some("2"), Some("3")],
+    );
+    check(
+        Span::new("@attr(1\n2\n3)"),
+        vec![Some("1"), Some("2"), Some("3")],
+    );
+    check(
+        Span::new("@attr(\n1\n2\n3\n)"),
+        vec![Some("1"), Some("2"), Some("3")],
+    );
+    check(Span::new("@attr(1,,3)"), vec![Some("1"), None, Some("3")]);
+    check(Span::new("@attr(,2,3)"), vec![None, Some("2"), Some("3")]);
+    check(Span::new("@attr(1,2,)"), vec![Some("1"), Some("2"), None]);
+}
+
+#[test]
+fn peel_tag_single_slot() {
+    let msg = Span::new("@attr(name : \"bob\")");
+    let result = super::peel_message(TestPeeler::default())(msg);
+
+    assert!(result.is_ok());
+    let (
+        _,
+        TestPeeler {
+            name,
+            slots,
+            values,
+            body,
+        },
+    ) = result.unwrap();
+
+    assert_eq!(name, Some("attr".to_string()));
+    assert_eq!(slots, vec![("name".to_string(), "\"bob\"")]);
+
+    assert!(values.is_empty());
+    assert_eq!(body, Some(""));
+}
+
+#[test]
+fn peel_tag_several_slots() {
+    let check = |msg, expected_slots, expected_values| {
+        let result = super::peel_message(TestPeeler::default())(msg);
+
+        assert!(result.is_ok());
+        let (
+            _,
+            TestPeeler {
+                name,
+                slots,
+                values,
+                body,
+            },
+        ) = result.unwrap();
+
+        assert_eq!(name, Some("attr".to_string()));
+        assert_eq!(slots, expected_slots);
+
+        assert_eq!(values, expected_values);
+        assert_eq!(body, Some(""));
+    };
+
+    check(
+        Span::new("@attr(first:1,second:2,third:3)"),
+        vec![
+            ("first".to_string(), "1"),
+            ("second".to_string(), "2"),
+            ("third".to_string(), "3"),
+        ],
+        vec![],
+    );
+    check(
+        Span::new("@attr( first:1, second:2, third:3 )"),
+        vec![
+            ("first".to_string(), "1"),
+            ("second".to_string(), "2"),
+            ("third".to_string(), "3"),
+        ],
+        vec![],
+    );
+    check(
+        Span::new("@attr( first: 1; second: 2; third: 3 )"),
+        vec![
+            ("first".to_string(), "1"),
+            ("second".to_string(), "2"),
+            ("third".to_string(), "3"),
+        ],
+        vec![],
+    );
+    check(
+        Span::new("@attr( first: 1\n second: 2\n third: 3 )"),
+        vec![
+            ("first".to_string(), "1"),
+            ("second".to_string(), "2"),
+            ("third".to_string(), "3"),
+        ],
+        vec![],
+    );
+    check(
+        Span::new("@attr(\nfirst: 1\n second: 2\n third: 3\n)"),
+        vec![
+            ("first".to_string(), "1"),
+            ("second".to_string(), "2"),
+            ("third".to_string(), "3"),
+        ],
+        vec![],
+    );
+    check(
+        Span::new("@attr( first:1, , third:3 )"),
+        vec![("first".to_string(), "1"), ("third".to_string(), "3")],
+        vec![None],
+    );
+    check(
+        Span::new("@attr( , second:2 , third:3 )"),
+        vec![("second".to_string(), "2"), ("third".to_string(), "3")],
+        vec![None],
+    );
+    check(
+        Span::new("@attr( first:1, second:2, )"),
+        vec![("first".to_string(), "1"), ("second".to_string(), "2")],
+        vec![None],
+    );
+}
+
+#[test]
+fn peel_body() {
+    let check = |msg, expected_body| {
+        let result = super::peel_message(TestPeeler::default())(msg);
+        assert!(result.is_ok());
+        let (
+            _,
+            TestPeeler {
+                name,
+                slots,
+                values,
+                body,
+            },
+        ) = result.unwrap();
+
+        assert_eq!(name, Some("attr".to_string()));
+        assert!(slots.is_empty());
+
+        assert_eq!(values, vec![Some("0")]);
+        assert_eq!(body, Some(expected_body));
+    };
+
+    check(Span::new("@attr(0) {}"), "{}");
+    check(Span::new("@attr(0) 1"), "1");
+    check(Span::new("@attr(0)@attr2 {}"), "@attr2 {}");
+    check(Span::new("@attr(0)@attr2 {\na:1\n}"), "@attr2 {\na:1\n}");
+}
+
+#[test]
+fn peel_complex() {
+    let msg = Span::new(
+        "@attr(@inner { 2, 7 }, key: @compound(5) { first: 1, second: name}) @other(1) {1,2,3}",
+    );
+    let result = super::peel_message(TestPeeler::default())(msg);
+
+    assert!(result.is_ok());
+    let (
+        _,
+        TestPeeler {
+            name,
+            slots,
+            values,
+            body,
+        },
+    ) = result.unwrap();
+
+    assert_eq!(name, Some("attr".to_string()));
+    assert_eq!(
+        slots,
+        vec![("key".to_string(), "@compound(5) { first: 1, second: name}")]
+    );
+
+    assert_eq!(values, vec![Some("@inner { 2, 7 }")]);
+    assert_eq!(body, Some("@other(1) {1,2,3}"));
 }

--- a/api/formats/swim_recon/src/parser/record/matcher/tests.rs
+++ b/api/formats/swim_recon/src/parser/record/matcher/tests.rs
@@ -1,0 +1,143 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nom::sequence::{delimited, preceded};
+use nom::character::complete::multispace0;
+use nom::combinator::eof;
+
+use nom::IResult;
+
+use crate::parser::Span;
+
+use super::HeaderPeeler;
+
+#[derive(Clone, Debug)]
+struct TestPeeler<'a> {
+    name: Option<String>,
+    slots: Vec<(String, Span<'a>)>,
+    values: Vec<Option<Span<'a>>>,
+    body: Option<Span<'a>>,
+}
+
+#[derive(Clone)]
+struct Inconsistent;
+
+impl<'a> HeaderPeeler<'a> for TestPeeler<'a> {
+    type Output = Self;
+
+    type Error = Inconsistent;
+
+    fn tag(mut self, name_str: &str) -> Result<Self, Self::Error> {
+        let TestPeeler { name, .. } = &mut self;
+        if name.is_some() {
+            Err(Inconsistent)
+        } else {
+            *name = Some(name_str.to_string());
+            Ok(self)
+        }
+    }
+
+    fn feed_header_slot(mut self, name: &str, value: Span<'a>) -> Result<Self, Self::Error> {
+        let TestPeeler { slots, .. } = &mut self;
+        slots.push((name.to_string(), value));
+        Ok(self)
+    }
+
+    fn feed_header_value(mut self, value: Span<'a>) -> Result<Self, Self::Error> {
+        let TestPeeler { values, .. } = &mut self;
+        values.push(Some(value));
+        Ok(self)
+    }
+
+    fn feed_header_extant(mut self) -> Result<Self, Self::Error> {
+        let TestPeeler { values, .. } = &mut self;
+        values.push(None);
+        Ok(self)
+    }
+
+    fn done(mut self, body_span: Span<'a>) -> Result<Self::Output, Self::Error> {
+        let TestPeeler { body, .. } = &mut self;
+        if body.is_some() {
+            Err(Inconsistent)
+        } else {
+            *body = Some(body_span);
+            Ok(self)
+        }
+    }
+}
+
+const RECON_DOCS: &[&str] = &[
+    "ident",
+    "\"two words\"",
+    "5",
+    "0.5",
+    "true",
+    "%YW55IGNhcm5hbCBwbGVhc3Vy",
+    "{}",
+    "@attr",
+    "@\"two words\"",
+    "@attr()",
+    "@attr {}",
+    "@attr() {}",
+    "@attr1@attr2",
+    "@attr1@attr2 {}",
+    "@attr1()@attr2() {}",
+    "@attr(0)",
+    "@attr(a:0)",
+    "@attr(0, 1, 2)",
+    "@attr(0; 1; 2)",
+    "@attr(a:0, b:1, c:2)",
+    "@attr(a:0; b:1; c:2)",
+    "@attr(a:0\n b:1\n c:2)",
+    "@attr(\na:0\n b:1\n c:2\n)",
+    "@attr(,)",
+    "@attr(,,)",
+    "@attr(\n,\n,\n)",
+    "{ 0 }",
+    "{ a:0 }",
+    "{ 0, 1, 2 }",
+    "{ 0; 1; 2 }",
+    "{ a:0, b:1, c:2 }",
+    "{ a:0; b:1; c:2 }",
+    "{ a:0\n b:1\n c:2 }",
+    "{\na:0\n b:1\n c:2\n}",
+    "{,}",
+    "{,,}",
+    "{\n,\n,\n}",
+    "@attr(@inner)",
+    "@attr(@inner{})",
+    "{ @attr }",
+    "{ @attr, @attr(@inner) }",
+    "{{}}",
+    "{{{}}}",
+    "{{},{}}",
+    "@attr 4",
+    "@attr() 4",
+];
+
+fn complete_value(input: Span<'_>) -> IResult<Span<'_>, Span<'_>> {
+    delimited(multispace0, super::value, preceded(multispace0, eof))(input)
+}
+
+#[test]
+fn recognize_values() {
+    for doc in RECON_DOCS {
+        let span = Span::new(*doc);
+        if let Ok((_, parsed)) = complete_value(span) {
+            assert_eq!(parsed, span);
+        } else {
+            panic!("Parse failed.");
+        }
+    }
+}

--- a/api/formats/swim_recon/src/parser/record/mod.rs
+++ b/api/formats/swim_recon/src/parser/record/mod.rs
@@ -26,7 +26,6 @@ use nom::{Finish, IResult, Parser};
 use std::borrow::Cow;
 use swim_form::structural::read::event::ReadEvent;
 
-//TODO Remove
 pub mod matcher;
 
 /// Change the state of the parser after producing an event.

--- a/api/formats/swim_recon/src/parser/record/mod.rs
+++ b/api/formats/swim_recon/src/parser/record/mod.rs
@@ -26,6 +26,9 @@ use nom::{Finish, IResult, Parser};
 use std::borrow::Cow;
 use swim_form::structural::read::event::ReadEvent;
 
+//TODO Remove
+pub mod matcher;
+
 /// Change the state of the parser after producing an event.
 #[derive(Debug)]
 enum StateChange {

--- a/api/formats/swim_recon/src/parser/tests.rs
+++ b/api/formats/swim_recon/src/parser/tests.rs
@@ -50,10 +50,8 @@ fn check_output_comments(result: IResult<Span<'_>, Vec<Span<'_>>>, offset: usize
 #[test]
 fn parse_identifier() {
     let input = span("name");
-    assert!(matches!(
-        streaming::identifier(input),
-        Err(nom::Err::Incomplete(_))
-    ));
+    let res: IResult<Span<'_>, &str> = streaming::identifier(input);
+    assert!(matches!(res, Err(nom::Err::Incomplete(_))));
 
     let input = span("name ");
     check_output(streaming::identifier(input), 4, "name");

--- a/api/swim_api/src/protocol/downlink/mod.rs
+++ b/api/swim_api/src/protocol/downlink/mod.rs
@@ -249,6 +249,7 @@ where
     }
 }
 
+#[derive(Debug, Default)]
 pub struct DownlinkOperationDecoder;
 
 impl Decoder for DownlinkOperationDecoder {

--- a/api/swim_api/src/protocol/map/mod.rs
+++ b/api/swim_api/src/protocol/map/mod.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::{FrameIoError, InvalidFrame};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use swim_form::structural::{read::recognizer::RecognizerReadable, write::StructuralWritable};
 use swim_model::Text;
 use swim_recon::parser::{AsyncParseError, RecognizerDecoder};
 use tokio_util::codec::{Decoder, Encoder};
 
+mod parser;
 #[cfg(test)]
 mod tests;
 
-use crate::error::{FrameIoError, InvalidFrame};
+pub use parser::extract_header;
 
 /// An operation that can be applied to a map lane. This type is used by map uplinks and downlinks
 /// to describe alterations to the lane.

--- a/api/swim_api/src/protocol/map/parser/mod.rs
+++ b/api/swim_api/src/protocol/map/parser/mod.rs
@@ -1,0 +1,184 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::ParseIntError;
+
+use bytes::Bytes;
+use swim_recon::parser::{try_extract_header, HeaderPeeler, MessageExtractError, Span};
+
+use super::{MapMessage, MapOperation};
+
+#[derive(Debug, Clone, Copy)]
+enum MessageKind {
+    Update,
+    Remove,
+    Clear,
+    Take,
+    Drop,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Chunk {
+    offset: usize,
+    len: usize,
+}
+
+impl<'a> From<Span<'a>> for Chunk {
+    fn from(span: Span<'a>) -> Self {
+        Chunk {
+            offset: span.location_offset(),
+            len: span.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct MapMessagePeeler {
+    kind: Option<MessageKind>,
+    key: Option<Chunk>,
+    num: Option<u64>,
+}
+
+#[derive(Clone)]
+enum MessagePeelError {
+    InvalidTag,
+    UnknownSlot,
+    UnexpectedValue,
+    DuplicateKey,
+    DuplicateSize,
+    BadSize,
+    Incomplete,
+}
+
+impl From<ParseIntError> for MessagePeelError {
+    fn from(_: ParseIntError) -> Self {
+        MessagePeelError::BadSize
+    }
+}
+
+impl<'a> HeaderPeeler<'a> for MapMessagePeeler {
+    type Output = MapMessage<Chunk, usize>;
+
+    type Error = MessagePeelError;
+
+    fn tag(mut self, name: &str) -> Result<Self, Self::Error> {
+        let MapMessagePeeler { kind, .. } = &mut self;
+        *kind = Some(match name {
+            "update" => MessageKind::Update,
+            "remove" => MessageKind::Remove,
+            "clear" => MessageKind::Clear,
+            "take" => MessageKind::Take,
+            "drop" => MessageKind::Drop,
+            _ => {
+                return Err(MessagePeelError::InvalidTag);
+            }
+        });
+        Ok(self)
+    }
+
+    fn feed_header_slot(mut self, name: &str, value: Span<'a>) -> Result<Self, Self::Error> {
+        let MapMessagePeeler { kind, key, .. } = &mut self;
+        if name == "key" && matches!(kind, Some(MessageKind::Update | MessageKind::Remove)) {
+            if key.is_some() {
+                Err(MessagePeelError::DuplicateKey)
+            } else {
+                *key = Some(value.into());
+                Ok(self)
+            }
+        } else {
+            Err(MessagePeelError::UnknownSlot)
+        }
+    }
+
+    fn feed_header_value(mut self, value: Span<'a>) -> Result<Self, Self::Error> {
+        let MapMessagePeeler { kind, num, .. } = &mut self;
+        if matches!(kind, Some(MessageKind::Take | MessageKind::Drop)) {
+            let n = value.parse::<u64>()?;
+            if num.is_some() {
+                Err(MessagePeelError::DuplicateSize)
+            } else {
+                *num = Some(n);
+                Ok(self)
+            }
+        } else {
+            Err(MessagePeelError::UnexpectedValue)
+        }
+    }
+
+    fn feed_header_extant(self) -> Result<Self, Self::Error> {
+        Ok(self)
+    }
+
+    fn done(self, body: Span<'a>) -> Result<Self::Output, Self::Error> {
+        match self {
+            MapMessagePeeler {
+                kind: Some(MessageKind::Update),
+                key: Some(k),
+                ..
+            } => Ok(MapOperation::Update {
+                key: k,
+                value: body.location_offset(),
+            }
+            .into()),
+            MapMessagePeeler {
+                kind: Some(MessageKind::Remove),
+                key: Some(k),
+                ..
+            } => Ok(MapOperation::Remove { key: k }.into()),
+            MapMessagePeeler {
+                kind: Some(MessageKind::Clear),
+                ..
+            } => Ok(MapOperation::Clear.into()),
+            MapMessagePeeler {
+                kind: Some(MessageKind::Take),
+                num: Some(n),
+                ..
+            } => Ok(MapMessage::Take(n)),
+            MapMessagePeeler {
+                kind: Some(MessageKind::Drop),
+                num: Some(n),
+                ..
+            } => Ok(MapMessage::Drop(n)),
+            _ => Err(MessagePeelError::Incomplete),
+        }
+    }
+}
+
+fn make_raw(bytes: &Bytes, peeled: MapMessage<Chunk, usize>) -> MapMessage<Bytes, Bytes> {
+    match peeled {
+        MapMessage::Operation(MapOperation::Update { key, value }) => {
+            let Chunk { offset, len } = key;
+            let key_bytes = bytes.slice(offset..(offset + len));
+            let value_bytes = bytes.slice(value..);
+            MapOperation::Update {
+                key: key_bytes,
+                value: value_bytes,
+            }
+            .into()
+        }
+        MapMessage::Operation(MapOperation::Remove { key }) => {
+            let Chunk { offset, len } = key;
+            let key_bytes = bytes.slice(offset..(offset + len));
+            MapOperation::Remove { key: key_bytes }.into()
+        }
+        MapMessage::Operation(MapOperation::Clear) => MapMessage::Operation(MapOperation::Clear),
+        MapMessage::Take(n) => MapMessage::Take(n),
+        MapMessage::Drop(n) => MapMessage::Drop(n),
+    }
+}
+
+pub fn extract_header(bytes: &Bytes) -> Result<MapMessage<Bytes, Bytes>, MessageExtractError> {
+    let offsets = try_extract_header(bytes, MapMessagePeeler::default())?;
+    Ok(make_raw(bytes, offsets))
+}

--- a/api/swim_api/src/protocol/map/parser/mod.rs
+++ b/api/swim_api/src/protocol/map/parser/mod.rs
@@ -19,6 +19,9 @@ use swim_recon::parser::{try_extract_header, HeaderPeeler, MessageExtractError, 
 
 use super::{MapMessage, MapOperation};
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Debug, Clone, Copy)]
 enum MessageKind {
     Update,

--- a/api/swim_api/src/protocol/map/parser/mod.rs
+++ b/api/swim_api/src/protocol/map/parser/mod.rs
@@ -31,6 +31,7 @@ enum MessageKind {
     Drop,
 }
 
+/// Description of a sub-string of the input.
 #[derive(Debug, Clone, Copy)]
 struct Chunk {
     offset: usize,
@@ -46,6 +47,10 @@ impl<'a> From<Span<'a>> for Chunk {
     }
 }
 
+/// Implementaton of [`HeaderPeeler`] that recognizes the header attribute of a warp map message.
+/// Rather than parsing the header, this recognizer simply keeps track of the kind of the message
+/// and where any key or value is located within the message so these can be extracted as
+/// substrings by the caller.
 #[derive(Debug, Clone, Copy, Default)]
 struct MapMessagePeeler {
     kind: Option<MessageKind>,
@@ -181,6 +186,7 @@ fn make_raw(bytes: &Bytes, peeled: MapMessage<Chunk, usize>) -> MapMessage<Bytes
     }
 }
 
+/// Attempt to interpet the header tag of a warp map message.
 pub fn extract_header(bytes: &Bytes) -> Result<MapMessage<Bytes, Bytes>, MessageExtractError> {
     let offsets = try_extract_header(bytes, MapMessagePeeler::default())?;
     Ok(make_raw(bytes, offsets))

--- a/api/swim_api/src/protocol/map/parser/tests.rs
+++ b/api/swim_api/src/protocol/map/parser/tests.rs
@@ -1,0 +1,106 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BytesMut;
+use std::fmt::Write;
+
+use crate::protocol::map::{MapMessage, MapOperation};
+
+#[test]
+fn peel_clear_header() {
+    let mut buffer = BytesMut::new();
+    write!(&mut buffer, "@clear").unwrap();
+
+    let bytes = buffer.freeze();
+
+    let result = super::extract_header(&bytes);
+    assert!(result.is_ok());
+
+    let message = result.unwrap();
+
+    assert!(matches!(
+        message,
+        MapMessage::Operation(MapOperation::Clear)
+    ));
+}
+
+#[test]
+fn peel_take_header() {
+    let mut buffer = BytesMut::new();
+    write!(&mut buffer, "@take(7)").unwrap();
+
+    let bytes = buffer.freeze();
+
+    let result = super::extract_header(&bytes);
+    assert!(result.is_ok());
+
+    let message = result.unwrap();
+
+    assert!(matches!(message, MapMessage::Take(7)));
+}
+
+#[test]
+fn peel_drop_header() {
+    let mut buffer = BytesMut::new();
+    write!(&mut buffer, "@drop(123)").unwrap();
+
+    let bytes = buffer.freeze();
+
+    let result = super::extract_header(&bytes);
+    assert!(result.is_ok());
+
+    let message = result.unwrap();
+
+    assert!(matches!(message, MapMessage::Drop(123)));
+}
+
+#[test]
+fn peel_remove_header() {
+    let mut buffer = BytesMut::new();
+    write!(&mut buffer, "@remove(key: 567)").unwrap();
+
+    let bytes = buffer.freeze();
+
+    let result = super::extract_header(&bytes);
+
+    match result {
+        Ok(MapMessage::Operation(MapOperation::Remove { key })) => {
+            assert_eq!(key.as_ref(), b"567");
+        }
+        ow => {
+            panic!("Unexpected result: {:?}", ow);
+        }
+    }
+}
+
+#[test]
+fn peel_update_header() {
+    let mut buffer = BytesMut::new();
+    let body = "@update(key: \"my key\")@inner { a: 1, b: 2}";
+    buffer.write_str(body).unwrap();
+
+    let bytes = buffer.freeze();
+
+    let result = super::extract_header(&bytes);
+
+    match result {
+        Ok(MapMessage::Operation(MapOperation::Update { key, value })) => {
+            assert_eq!(key.as_ref(), b"\"my key\"");
+            assert_eq!(value.as_ref(), b"@inner { a: 1, b: 2}");
+        }
+        ow => {
+            panic!("Unexpected result: {:?}", ow);
+        }
+    }
+}

--- a/runtime/swim_runtime/src/downlink/backpressure/mod.rs
+++ b/runtime/swim_runtime/src/downlink/backpressure/mod.rs
@@ -1,0 +1,156 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{convert::Infallible, str::Utf8Error, fmt::Display};
+
+use bytes::{Bytes, BytesMut, BufMut};
+use swim_api::protocol::{downlink::{DownlinkOperation, DownlinkOperationDecoder}, map::{RawMapOperation, RawMapOperationEncoder, RawMapOperationDecoder}};
+use tokio_util::codec::{Decoder, Encoder};
+
+use super::map_queue::MapOperationQueue;
+
+pub trait DownlinkBackpressure {
+
+    type Operation;
+    type Dec: Decoder<Item = Self::Operation>;
+    type Err: Display;
+
+    fn make_decoder() -> Self::Dec;
+
+    fn push_operation(&mut self, op: Self::Operation) -> Result<(), Self::Err>;
+
+    fn write_direct(&mut self, op: Self::Operation, buffer: &mut BytesMut);
+
+    fn has_data(&self) -> bool;
+
+    fn prepare_write(&mut self, buffer: &mut BytesMut);
+
+}
+
+#[derive(Debug)]
+pub enum DebugEvent {
+    HasData(bool),
+    Push(Vec<u8>),
+    WriteDirect(Vec<u8>),
+    PrepareWrite(Vec<u8>, Vec<u8>)
+}
+
+#[derive(Debug, Default)]
+pub struct ValueBackpressure {
+    tx: Option<tokio::sync::mpsc::UnboundedSender<DebugEvent>>,
+    current: BytesMut,
+}
+
+impl ValueBackpressure {
+
+    pub fn new(tx: tokio::sync::mpsc::UnboundedSender<DebugEvent>) -> Self {
+        ValueBackpressure {
+            tx: Some(tx),
+            current: Default::default(),
+        }
+    }
+
+}
+
+#[derive(Debug, Default)]
+pub struct MapBackpressure {
+    queue: MapOperationQueue,
+    encoder: RawMapOperationEncoder,
+}
+
+impl DownlinkBackpressure for ValueBackpressure {
+    type Operation = DownlinkOperation<Bytes>;
+
+    type Dec = DownlinkOperationDecoder;
+    type Err = Infallible;
+
+    fn make_decoder() -> Self::Dec {
+        Default::default()
+    }
+
+    fn push_operation(&mut self, op: Self::Operation) -> Result<(), Infallible> {
+        let ValueBackpressure { tx, current } = self;
+        let DownlinkOperation { body } = op;
+        
+        if let Some(tx) = tx {
+            let _ = tx.send(DebugEvent::Push(body.to_vec()));
+        }
+        
+        current.reserve(body.len());
+        current.put(body);
+        Ok(())
+    }
+
+    fn has_data(&self) -> bool {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(DebugEvent::HasData(!self.current.is_empty()));
+        }
+        !self.current.is_empty()
+    }
+
+    fn write_direct(&mut self, op: Self::Operation, buffer: &mut BytesMut) {
+        let DownlinkOperation { body } = op;
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(DebugEvent::WriteDirect(body.to_vec()));
+        }
+        buffer.reserve(body.len());
+        buffer.put(body);
+    }
+
+    fn prepare_write(&mut self, buffer: &mut BytesMut) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(DebugEvent::PrepareWrite(self.current.to_vec(), buffer.to_vec()));
+        }
+        std::mem::swap(&mut self.current, buffer);
+        self.current.clear()
+    }
+}
+
+impl DownlinkBackpressure for MapBackpressure {
+    
+    type Operation = RawMapOperation;
+
+    type Dec = RawMapOperationDecoder;
+    type Err = Utf8Error;
+
+    fn make_decoder() -> Self::Dec {
+        Default::default()
+    }
+
+    fn push_operation(&mut self, op: Self::Operation) -> Result<(), Utf8Error> {
+        self.queue.push(op)
+    }
+
+    fn has_data(&self) -> bool {
+        !self.queue.is_empty()
+    }
+
+    fn write_direct(&mut self, op: Self::Operation, buffer: &mut BytesMut) {
+        let MapBackpressure {
+            encoder, ..
+        } = self;
+         // Encoding the operation cannot fail.
+        encoder.encode(op, buffer).expect("Encoding should be unfallible.");
+    }
+
+    fn prepare_write(&mut self, buffer: &mut BytesMut) {
+        let MapBackpressure {
+            queue, encoder,
+        } = self;
+        if let Some(head) = queue.pop() {
+            // Encoding the operation cannot fail.
+            encoder.encode(head, buffer).expect("Encoding should be unfallible.");
+        }
+    }
+}

--- a/runtime/swim_runtime/src/downlink/map_queue/tests.rs
+++ b/runtime/swim_runtime/src/downlink/map_queue/tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::RandomState;
+
 use bytes::{BufMut, Bytes, BytesMut};
 
 use super::MapOperationQueue;
@@ -252,8 +254,10 @@ fn clear_when_filled() {
 // actually ocurr but we should be robust against it.
 #[test]
 fn epoch_overflow() {
-    let mut queue = MapOperationQueue::default();
-    queue.head_epoch = usize::MAX - 2;
+    let mut queue = MapOperationQueue::<RandomState> {
+        head_epoch: usize::MAX - 2,
+        ..Default::default()
+    };
 
     for i in 0..5 {
         let key = format!("key{}", i);

--- a/runtime/swim_runtime/src/downlink/mod.rs
+++ b/runtime/swim_runtime/src/downlink/mod.rs
@@ -42,6 +42,7 @@ use crate::compat::{
 };
 use crate::routing::RoutingAddr;
 
+pub mod backpressure;
 mod key;
 pub mod map_queue;
 #[cfg(test)]

--- a/runtime/swim_runtime/src/downlink/mod.rs
+++ b/runtime/swim_runtime/src/downlink/mod.rs
@@ -17,14 +17,12 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use bitflags::bitflags;
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{BufMut, BytesMut};
 use futures::future::{join, select, Either};
 use futures::stream::SelectAll;
 use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
 use pin_utils::pin_mut;
-use swim_api::protocol::downlink::{
-    DownlinkNotification, DownlinkNotificationEncoder, DownlinkOperation, DownlinkOperationDecoder,
-};
+use swim_api::protocol::downlink::{DownlinkNotification, DownlinkNotificationEncoder};
 use swim_model::path::RelativePath;
 use swim_utilities::future::{immediate_or_join, immediate_or_start, SecondaryResult};
 use swim_utilities::io::byte_channel::{ByteReader, ByteWriter};
@@ -32,7 +30,7 @@ use swim_utilities::trigger;
 use tokio::sync::mpsc;
 use tokio::time::{timeout, timeout_at, Instant};
 use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::codec::{Encoder, FramedRead, FramedWrite};
+use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite};
 use tracing::{error, info, info_span, trace, warn};
 use tracing_futures::Instrument;
 
@@ -40,6 +38,7 @@ use crate::compat::{
     Notification, Operation, RawRequestMessage, RawRequestMessageEncoder, RawResponseMessage,
     RawResponseMessageDecoder,
 };
+use crate::downlink::backpressure::DownlinkBackpressure;
 use crate::routing::RoutingAddr;
 
 pub mod backpressure;
@@ -64,12 +63,10 @@ bitflags! {
 bitflags! {
     /// Internal flags for the downlink runtime write task.
     struct WriteTaskState: u8 {
-        /// A new value has been received while a write was pending.
-        const UPDATED = 0b001;
         /// The outgoing channel has been flushed.
-        const FLUSHED = 0b010;
+        const FLUSHED = 0b01;
         /// A new consumer that needs to be synced has joined why a write was pending.
-        const NEEDS_SYNC = 0b100;
+        const NEEDS_SYNC = 0b10;
         /// When the task starts it does not need to be flushed.
         const INIT = Self::FLUSHED.bits;
     }
@@ -181,6 +178,7 @@ impl ValueDownlinkRuntime {
             identity,
             path.clone(),
             config,
+            ValueBackpressure::default(),
         )
         .instrument(info_span!("Downlink Runtime Write Task", %path));
         let io = async move {
@@ -274,16 +272,16 @@ where
 }
 
 /// Receiver to receive commands from downlink subscribers.
-struct DownlinkReceiver {
-    receiver: FramedRead<ByteReader, DownlinkOperationDecoder>,
+struct DownlinkReceiver<D> {
+    receiver: FramedRead<ByteReader, D>,
     id: u64,
     terminated: bool,
 }
 
-impl DownlinkReceiver {
-    fn new(reader: ByteReader, id: u64) -> Self {
+impl<D: Decoder> DownlinkReceiver<D> {
+    fn new(reader: ByteReader, id: u64, decoder: D) -> Self {
         DownlinkReceiver {
-            receiver: FramedRead::new(reader, DownlinkOperationDecoder),
+            receiver: FramedRead::new(reader, decoder),
             id,
             terminated: false,
         }
@@ -297,8 +295,8 @@ impl DownlinkReceiver {
 
 struct Failed(u64);
 
-impl Stream for DownlinkReceiver {
-    type Item = Result<DownlinkOperation<Bytes>, Failed>;
+impl<D: Decoder> Stream for DownlinkReceiver<D> {
+    type Item = Result<D::Item, Failed>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
@@ -610,13 +608,14 @@ async fn do_flush(
 
 /// Receives commands for the subscribers to the downlink and writes them to the outgoing channel.
 /// If commands are received faster than the channel can send them, some records will be dropped.
-async fn write_task(
+async fn write_task<B: DownlinkBackpressure>(
     output: ByteWriter,
     producers: mpsc::Receiver<(ByteReader, DownlinkOptions)>,
     stopping: trigger::Receiver,
     identity: RoutingAddr,
     path: RelativePath,
     config: DownlinkRuntimeConfig,
+    mut backpressure: B,
 ) {
     let mut message_writer = RequestSender::new(output, identity, path);
     if message_writer.send_link().await.is_err() {
@@ -627,9 +626,8 @@ async fn write_task(
         message_writer,
         buffer: BytesMut::new(),
     };
-    let mut current = BytesMut::new();
 
-    let mut registered: SelectAll<DownlinkReceiver> = SelectAll::new();
+    let mut registered: SelectAll<DownlinkReceiver<B::Dec>> = SelectAll::new();
     let mut reg_requests = ReceiverStream::new(producers).take_until(stopping);
     // Consumers are given unique IDs to allow them to be removed when they fail.
     let mut id: u64 = 0;
@@ -655,8 +653,9 @@ async fn write_task(
     // Flags
     // =====
     //
-    // UPDATED:     While a write or flush was occurring, at least one new command has been received and
-    //              another write needs to be scheduled.
+    // HAS_DATA:    While a write or flush was occurring, at least one new command has been received and
+    //              another write needs to be scheduled. This is stored implicitly in the bakpressure
+    //              implementation.
     // FLUSHED:     Indicates that all data written to the output has been flushed.
     // NEEDS_SYNC:  While a write or flush was ocurring, a new subscriber was added that requested a SYNC
     //              message to be sent and this should be sent at the next opportunity.
@@ -677,14 +676,14 @@ async fn write_task(
     //          2. If a command is received and:
     //              a. The flush did not start or completed successfully. We move to the Writing state, writing
     //                 the command.
-    //              b. The flush started and did not complete. The command is written into a buffer, the UPDATED
+    //              b. The flush started and did not complete. The command is written into a buffer, the HAS_DATA
     //                 flag is set and we move into the Flushing state.
     // Writing: A write (of a command or SYNC message) is pending. In this state it will wait for the write to
     //          complete and for new subscribers and outgoing commands from existing subscribers.
     //          1. If the write completes and:
     //              a. The NEEDS_SYNC flag is set. A new write is scheduled for the SYNC and we remain in the
     //                 Writing state.
-    //              b. The UPDATED flag is set. A new write is scheduled for the contents of the buffer and we
+    //              b. The HAS_DATA flag is set. A new write is scheduled for the contents of the buffer and we
     //                 remain in the Writing state.
     //              c. Otherwise we move back to the Idle state.
     'outer: loop {
@@ -712,7 +711,8 @@ async fn write_task(
                     match req_result {
                         Ok(Some((reader, options))) => {
                             trace!("Registering new subscriber.");
-                            let receiver = DownlinkReceiver::new(reader, next_id());
+                            let receiver =
+                                DownlinkReceiver::new(reader, next_id(), B::make_decoder());
                             registered.push(receiver);
                             if options.contains(DownlinkOptions::SYNC) {
                                 trace!("Sending a Sync message.");
@@ -757,7 +757,8 @@ async fn write_task(
                     };
                     match next_op {
                         Either::Left(Some((reader, options))) => {
-                            let receiver = DownlinkReceiver::new(reader, next_id());
+                            let receiver =
+                                DownlinkReceiver::new(reader, next_id(), B::make_decoder());
                             registered.push(receiver);
                             match flush_outcome {
                                 Either::Left(message_writer) => {
@@ -785,30 +786,26 @@ async fn write_task(
                             info!("Stopping after dropped by the runtime.");
                             break 'outer;
                         }
-                        Either::Right(Some(Ok(DownlinkOperation { body }))) => {
-                            match flush_outcome {
-                                Either::Left(message_writer) => {
-                                    trace!("Dispatching an event.");
-                                    buffer.clear();
-                                    buffer.reserve(body.len());
-                                    buffer.put(body);
-                                    let write_fut =
-                                        suspend_write(message_writer, buffer, WriteKind::Data);
-                                    task_state
-                                        .remove(WriteTaskState::FLUSHED | WriteTaskState::UPDATED);
-                                    state = WriteState::Writing(Either::Left(write_fut));
-                                }
-                                Either::Right(flush) => {
-                                    trace!("Storing an event in the buffer and waiting on a flush to compelte.");
-                                    current.clear();
-                                    current.reserve(body.len());
-                                    current.put(body);
-                                    task_state |= WriteTaskState::UPDATED;
-                                    state =
-                                        WriteState::Writing(Either::Right(do_flush(flush, buffer)));
-                                }
+                        Either::Right(Some(Ok(op))) => match flush_outcome {
+                            Either::Left(message_writer) => {
+                                trace!("Dispatching an event.");
+                                backpressure.write_direct(op, &mut buffer);
+                                let write_fut =
+                                    suspend_write(message_writer, buffer, WriteKind::Data);
+                                task_state.remove(WriteTaskState::FLUSHED);
+                                state = WriteState::Writing(Either::Left(write_fut));
                             }
-                        }
+                            Either::Right(flush) => {
+                                trace!("Storing an event in the buffer and waiting on a flush to compelte.");
+                                if let Err(err) = backpressure.push_operation(op) {
+                                    error!(
+                                        "Failed to process downlink operaton: {error}",
+                                        error = err
+                                    );
+                                };
+                                state = WriteState::Writing(Either::Right(do_flush(flush, buffer)));
+                            }
+                        },
                         Either::Right(ow) => {
                             if let Some(Err(Failed(id))) = ow {
                                 trace!("Removing a failed subscriber");
@@ -865,13 +862,12 @@ async fn write_task(
                                     .remove(WriteTaskState::FLUSHED | WriteTaskState::NEEDS_SYNC);
                                 let write = suspend_write(message_writer, buffer, WriteKind::Sync);
                                 state = WriteState::Writing(Either::Left(write));
-                            } else if task_state.contains(WriteTaskState::UPDATED) {
+                            } else if backpressure.has_data() {
                                 trace!("Dispatching the updated buffer.");
-                                std::mem::swap(&mut buffer, &mut current);
+                                backpressure.prepare_write(&mut buffer);
                                 let write_fut =
                                     suspend_write(message_writer, buffer, WriteKind::Data);
-                                task_state
-                                    .remove(WriteTaskState::FLUSHED | WriteTaskState::UPDATED);
+                                task_state.remove(WriteTaskState::FLUSHED);
                                 state = WriteState::Writing(Either::Left(write_fut));
                             } else {
                                 trace!("Task has become idle.");
@@ -883,13 +879,12 @@ async fn write_task(
                             // The write has completed so we can return to the outer loop.
                             break 'inner;
                         }
-                        SuspendedResult::NextRecord(Some(Ok(DownlinkOperation { body }))) => {
+                        SuspendedResult::NextRecord(Some(Ok(op))) => {
                             // Writing is currently blocked so overwrite the next value to be sent.
                             trace!("Over-writing the current event buffer.");
-                            current.clear();
-                            current.reserve(body.len());
-                            current.put(body);
-                            task_state |= WriteTaskState::UPDATED;
+                            if let Err(err) = backpressure.push_operation(op) {
+                                error!("Failed to process downlink operaton: {error}", error = err);
+                            };
                         }
                         SuspendedResult::NextRecord(Some(Err(Failed(id)))) => {
                             trace!("Removing a failed subscriber.");
@@ -899,7 +894,8 @@ async fn write_task(
                         }
                         SuspendedResult::NewRegistration(Some((reader, options))) => {
                             trace!("Registering a new subscriber.");
-                            let receiver = DownlinkReceiver::new(reader, next_id());
+                            let receiver =
+                                DownlinkReceiver::new(reader, next_id(), B::make_decoder());
                             registered.push(receiver);
                             task_state.set_needs_sync(options);
                         }
@@ -918,6 +914,8 @@ async fn write_task(
 use futures::ready;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+use self::backpressure::ValueBackpressure;
 
 /// A future that flushes a sender and then returns it. This is necessary as we need
 /// an [`Unpin`] future so an equivlanent async block would not work.


### PR DESCRIPTION
Adds a new capability to the parser for peeling off and interpreting the first attribute of a recon document without creating a `Value` object. Provides an implementation for warp map operations.