### PR TITLE
Adds a new type of uplink to the runtime to support supply lanes.

### DIFF
--- a/api/swim_api/src/agent/mod.rs
+++ b/api/swim_api/src/agent/mod.rs
@@ -37,6 +37,7 @@ use crate::{
 pub enum UplinkKind {
     Value,
     Map,
+    Supply,
 }
 
 impl Display for UplinkKind {
@@ -44,6 +45,7 @@ impl Display for UplinkKind {
         match self {
             UplinkKind::Value => f.write_str("Value"),
             UplinkKind::Map => f.write_str("Map"),
+            UplinkKind::Supply => f.write_str("Supply"),
         }
     }
 }

--- a/runtime/swim_runtime/src/agent/store/mod.rs
+++ b/runtime/swim_runtime/src/agent/store/mod.rs
@@ -15,7 +15,6 @@
 use bytes::BytesMut;
 use futures::{future::BoxFuture, FutureExt, SinkExt};
 use swim_api::{
-    agent::UplinkKind,
     error::StoreError,
     protocol::{
         agent::{LaneRequest, LaneRequestEncoder},
@@ -227,12 +226,14 @@ where
 struct NoValueInit;
 struct NoMapInit;
 
-/// Dummy initializer for when there is no store.
-pub fn no_store_init<'a>(kind: UplinkKind) -> BoxInitializer<'a> {
-    match kind {
-        UplinkKind::Value => Box::new(NoValueInit),
-        UplinkKind::Map => Box::new(NoMapInit),
-    }
+/// Dummy initializer for when there is no store for a value.
+pub fn no_value_init<'a>() -> BoxInitializer<'a> {
+    Box::new(NoValueInit)
+}
+
+/// Dummy initializer for when there is no store for a map.
+pub fn no_map_init<'a>() -> BoxInitializer<'a> {
+    Box::new(NoMapInit)
 }
 
 impl<'a> Initializer<'a> for NoValueInit {

--- a/runtime/swim_runtime/src/agent/task/init/mod.rs
+++ b/runtime/swim_runtime/src/agent/task/init/mod.rs
@@ -172,7 +172,7 @@ impl<Store: AgentPersistence + Clone + Send + Sync> AgentInitTask<Store> {
                                     let lane_id = get_lane_id()?;
                                     Some(
                                         store
-                                            .init_value_lane(lane_id)
+                                            .init_map_lane(lane_id)
                                             .unwrap_or_else(|| no_map_init()),
                                     )
                                 }

--- a/runtime/swim_runtime/src/agent/task/init/tests/mod.rs
+++ b/runtime/swim_runtime/src/agent/task/init/tests/mod.rs
@@ -107,11 +107,11 @@ fn check_connected(first: &mut Io, second: &mut Io) {
 }
 
 #[derive(Default)]
-struct DummtInit {
+struct DummyInit {
     error: Option<StoreInitError>,
 }
 
-impl<'a> Initializer<'a> for DummtInit {
+impl<'a> Initializer<'a> for DummyInit {
     fn initialize<'b>(self: Box<Self>, writer: &'b mut ByteWriter) -> InitFut<'b>
     where
         'a: 'b,
@@ -147,7 +147,7 @@ async fn run_initializer_success() {
             LANE_INIT_TIMEOUT,
             tx_in,
             rx_out,
-            Box::new(DummtInit::default()),
+            Box::new(DummyInit::default()),
         );
 
         let test_task = async {
@@ -184,7 +184,7 @@ async fn run_initializer_failed_init() {
     tokio::time::timeout(TEST_TIMEOUT, async {
         let (tx_in, _rx_in) = byte_channel(BUFFER_SIZE);
         let (_tx_out, rx_out) = byte_channel(BUFFER_SIZE);
-        let init = DummtInit {
+        let init = DummyInit {
             error: Some(StoreInitError::Store(StoreError::KeyspaceNotFound)),
         };
         let init_task = super::lane_initialization(
@@ -222,7 +222,7 @@ async fn run_initializer_bad_response() {
             LANE_INIT_TIMEOUT,
             tx_in,
             rx_out,
-            Box::new(DummtInit::default()),
+            Box::new(DummyInit::default()),
         );
 
         let test_task = async {
@@ -271,7 +271,7 @@ async fn run_initializer_timeout() {
             Duration::from_millis(100),
             tx_in,
             rx_out,
-            Box::new(DummtInit::default()),
+            Box::new(DummyInit::default()),
         );
 
         let test_task = async {

--- a/runtime/swim_runtime/src/agent/task/init/tests/no_store.rs
+++ b/runtime/swim_runtime/src/agent/task/init/tests/no_store.rs
@@ -336,6 +336,7 @@ async fn two_lanes() {
                     assert_eq!(name, "map_lane");
                     check_connected(&mut map, &mut io);
                 }
+                _ => panic!("Unexpected supply uplink."),
             }
         }
     }

--- a/runtime/swim_runtime/src/agent/task/tests/coordination.rs
+++ b/runtime/swim_runtime/src/agent/task/tests/coordination.rs
@@ -146,6 +146,9 @@ impl FakeAgent {
                     let init = initial_state.map_lanes.remove(&name).unwrap_or_default();
                     map_lanes.insert(name.clone(), (init, MapLaneSender::new(io_tx)));
                 }
+                UplinkKind::Supply => {
+                    panic!("Unexpected supply uplink.");
+                }
             }
             lanes.push(LaneReader::new(LaneEndpoint {
                 name,
@@ -252,6 +255,9 @@ impl FakeAgent {
                             UplinkKind::Map => {
                                 let m: BTreeMap<Text, i32> = BTreeMap::new();
                                 map_lanes.insert(name.clone(), (m, MapLaneSender::new(io_tx)));
+                            }
+                            UplinkKind::Supply => {
+                                panic!("Unexpected supply uplink.");
                             }
                         }
                         lanes.push(LaneReader::new(LaneEndpoint { name, kind, transient: false, io: io_rx }));

--- a/runtime/swim_runtime/src/agent/task/tests/coordination.rs
+++ b/runtime/swim_runtime/src/agent/task/tests/coordination.rs
@@ -47,8 +47,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
 
 use super::{
-    make_prune_config, LaneReader, MapLaneSender, ValueLaneSender, BUFFER_SIZE, DEFAULT_TIMEOUT,
-    INACTIVE_TEST_TIMEOUT, MAP_LANE, QUEUE_SIZE, TEST_TIMEOUT, VAL_LANE,
+    make_prune_config, LaneReader, MapLaneSender, ValueLikeLaneSender, BUFFER_SIZE,
+    DEFAULT_TIMEOUT, INACTIVE_TEST_TIMEOUT, MAP_LANE, QUEUE_SIZE, TEST_TIMEOUT, VAL_LANE,
 };
 
 #[derive(Debug, Clone)]
@@ -76,7 +76,7 @@ struct AgentState {
 
 impl AgentState {
     fn new(
-        val: HashMap<Text, (i32, ValueLaneSender)>,
+        val: HashMap<Text, (i32, ValueLikeLaneSender)>,
         map: HashMap<Text, (BTreeMap<Text, i32>, MapLaneSender)>,
     ) -> Self {
         let value_lanes = val.into_iter().map(|(k, (n, _))| (k, n)).collect();
@@ -140,7 +140,7 @@ impl FakeAgent {
             match kind {
                 UplinkKind::Value => {
                     let init = initial_state.value_lanes.remove(&name).unwrap_or_default();
-                    value_lanes.insert(name.clone(), (init, ValueLaneSender::new(io_tx)));
+                    value_lanes.insert(name.clone(), (init, ValueLikeLaneSender::new(io_tx)));
                 }
                 UplinkKind::Map => {
                     let init = initial_state.map_lanes.remove(&name).unwrap_or_default();
@@ -250,7 +250,7 @@ impl FakeAgent {
                             .expect("Failed to add new lane.");
                         match kind {
                             UplinkKind::Value => {
-                                value_lanes.insert(name.clone(), (0, ValueLaneSender::new(io_tx)));
+                                value_lanes.insert(name.clone(), (0, ValueLikeLaneSender::new(io_tx)));
                             }
                             UplinkKind::Map => {
                                 let m: BTreeMap<Text, i32> = BTreeMap::new();
@@ -797,7 +797,7 @@ async fn receive_messages_when_linked() {
                 sender.link(VAL_LANE).await;
                 receiver.expect_linked(VAL_LANE).await;
                 linked_tx.trigger();
-                receiver.expect_value_event(VAL_LANE, v).await;
+                receiver.expect_value_like_event(VAL_LANE, v).await;
                 receiver
             };
 
@@ -882,7 +882,7 @@ async fn receive_messages_when_liked_multiple_consumers() {
                 sender.link(VAL_LANE).await;
                 receiver.expect_linked(VAL_LANE).await;
                 linked_tx1.trigger();
-                receiver.expect_value_event(VAL_LANE, v).await;
+                receiver.expect_value_like_event(VAL_LANE, v).await;
                 receiver
             };
 
@@ -891,7 +891,7 @@ async fn receive_messages_when_liked_multiple_consumers() {
                 sender.link(VAL_LANE).await;
                 receiver.expect_linked(VAL_LANE).await;
                 linked_tx2.trigger();
-                receiver.expect_value_event(VAL_LANE, v).await;
+                receiver.expect_value_like_event(VAL_LANE, v).await;
                 receiver
             };
 

--- a/runtime/swim_runtime/src/agent/task/tests/mod.rs
+++ b/runtime/swim_runtime/src/agent/task/tests/mod.rs
@@ -287,7 +287,7 @@ impl LaneReader {
     fn new(endpoint: LaneEndpoint<ByteReader>) -> Self {
         let LaneEndpoint { name, kind, io, .. } = endpoint;
         match kind {
-            UplinkKind::Value => LaneReader::Value {
+            UplinkKind::Value | UplinkKind::Supply => LaneReader::Value {
                 name,
                 read: FramedRead::new(
                     io,

--- a/runtime/swim_runtime/src/agent/task/tests/write.rs
+++ b/runtime/swim_runtime/src/agent/task/tests/write.rs
@@ -90,6 +90,9 @@ impl FakeAgent {
                 UplinkKind::Map => {
                     map_lanes.insert(name, MapLaneSender::new(io));
                 }
+                _ => {
+                    panic!("Unexpected supply uplink.");
+                }
             }
         }
 

--- a/runtime/swim_runtime/src/pressure/mod.rs
+++ b/runtime/swim_runtime/src/pressure/mod.rs
@@ -142,7 +142,7 @@ impl BackpressureStrategy for ValueBackpressure {
 
     fn prepare_write(&mut self, buffer: &mut BytesMut) {
         std::mem::swap(&mut self.current, buffer);
-        self.current.clear()
+        self.current.clear();
     }
 }
 

--- a/runtime/swim_runtime/src/pressure/mod.rs
+++ b/runtime/swim_runtime/src/pressure/mod.rs
@@ -30,6 +30,9 @@ use recon::MapOperationReconEncoder;
 
 use crate::error::InvalidKey;
 
+#[cfg(test)]
+mod tests;
+
 /// Backpressure strategy for the output task of a downlink. This is used to encode the
 /// difference in behaviour between different kinds of downlink (particuarly value and
 /// map downlinks.)

--- a/runtime/swim_runtime/src/pressure/tests.rs
+++ b/runtime/swim_runtime/src/pressure/tests.rs
@@ -1,0 +1,164 @@
+// Copyright 2015-2021 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::{Bytes, BytesMut};
+use swim_api::protocol::downlink::DownlinkOperation;
+
+use crate::pressure::{BackpressureStrategy, SupplyBackpressure};
+
+use super::ValueBackpressure;
+
+#[test]
+fn value_backpressure_empty() {
+    let mut backpressure = ValueBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+    backpressure.prepare_write(&mut buffer);
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn supply_backpressure_empty() {
+    let mut backpressure = SupplyBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+    backpressure.prepare_write(&mut buffer);
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn value_backpressure_write_direct() {
+    let mut backpressure = ValueBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+    backpressure.write_direct(
+        DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])),
+        &mut buffer,
+    );
+
+    assert_eq!(buffer.as_ref(), &[1, 2, 3]);
+}
+
+#[test]
+fn supply_backpressure_write_direct() {
+    let mut backpressure = SupplyBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+    backpressure.write_direct(
+        DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])),
+        &mut buffer,
+    );
+
+    assert_eq!(buffer.as_ref(), &[1, 2, 3]);
+}
+
+#[test]
+fn value_backpressure_push_data() {
+    let mut backpressure = ValueBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])))
+        .unwrap();
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[1, 2, 3]);
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+}
+
+#[test]
+fn supply_backpressure_push_data() {
+    let mut backpressure = SupplyBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])))
+        .unwrap();
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[1, 2, 3]);
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+}
+
+#[test]
+fn value_backpressure_push_multiple() {
+    let mut backpressure = ValueBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])))
+        .unwrap();
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[4, 5, 6])))
+        .unwrap();
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[7, 8, 9])))
+        .unwrap();
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[7, 8, 9]);
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+}
+
+#[test]
+fn supply_backpressure_push_multiple() {
+    let mut backpressure = SupplyBackpressure::default();
+
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[1, 2, 3])))
+        .unwrap();
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[4, 5, 6])))
+        .unwrap();
+    backpressure
+        .push_operation(DownlinkOperation::new(Bytes::copy_from_slice(&[7, 8, 9])))
+        .unwrap();
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    let mut buffer = BytesMut::new();
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[1, 2, 3]);
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[4, 5, 6]);
+    assert!(BackpressureStrategy::has_data(&backpressure));
+
+    backpressure.prepare_write(&mut buffer);
+    assert_eq!(buffer.as_ref(), &[7, 8, 9]);
+    assert!(!BackpressureStrategy::has_data(&backpressure));
+}

--- a/server/swim_agent/src/agent_model/mod.rs
+++ b/server/swim_agent/src/agent_model/mod.rs
@@ -437,6 +437,7 @@ where
                 match kind {
                     UplinkKind::Value => value_lane_io.insert(Text::new(name), io),
                     UplinkKind::Map => map_lane_io.insert(Text::new(name), io),
+                    UplinkKind::Supply => todo!("Supply lanes not yet implemented."),
                 };
             }
         }


### PR DESCRIPTION
Adds supply uplinks to the runtime for #506. These behave the same as value uplinks but without backpressure relief.