### PR TITLE
Passing route parameters into agents.

### DIFF
--- a/api/swim_api/src/agent/mod.rs
+++ b/api/swim_api/src/agent/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    collections::HashMap,
     fmt::{Display, Formatter},
     num::NonZeroUsize,
 };
@@ -165,11 +166,13 @@ pub trait Agent {
     /// then yield another future that will actually run the agent.
     /// #Arguments
     /// * `route` - The node URI of this agent instance.
+    /// * `route_params` - Parameters extracted from the route URI.
     /// * `config` - Configuration parameters for the agent.
     /// * `context` - Context through which the agent can interact with the runtime.
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult>;
@@ -183,10 +186,11 @@ impl Agent for BoxAgent {
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult> {
-        (**self).run(route, config, context)
+        (**self).run(route, route_params, config, context)
     }
 }
 
@@ -197,9 +201,10 @@ where
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult> {
-        (*self).run(route, config, context)
+        (*self).run(route, route_params, config, context)
     }
 }

--- a/runtime/swim_runtime/src/agent/mod.rs
+++ b/runtime/swim_runtime/src/agent/mod.rs
@@ -37,6 +37,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use std::{
+    collections::HashMap,
     fmt::{Debug, Display},
     future::Future,
     num::NonZeroUsize,
@@ -369,6 +370,7 @@ pub enum AgentExecError {
 pub struct AgentRoute {
     pub identity: Uuid,
     pub route: RouteUri,
+    pub route_params: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -380,6 +382,7 @@ pub struct AgentRouteTask<'a, A> {
     agent: &'a A,
     identity: Uuid,
     route: RouteUri,
+    route_params: HashMap<String, String>,
     attachment_rx: mpsc::Receiver<AgentAttachmentRequest>,
     downlink_tx: mpsc::Sender<DownlinkRequest>,
     stopping: trigger::Receiver,
@@ -411,6 +414,7 @@ impl<'a, A: Agent + 'static> AgentRouteTask<'a, A> {
             agent,
             identity: identity.identity,
             route: identity.route,
+            route_params: identity.route_params,
             attachment_rx,
             downlink_tx,
             stopping,
@@ -425,6 +429,7 @@ impl<'a, A: Agent + 'static> AgentRouteTask<'a, A> {
             agent,
             identity,
             route,
+            route_params,
             attachment_rx,
             downlink_tx,
             stopping,
@@ -444,7 +449,7 @@ impl<'a, A: Agent + 'static> AgentRouteTask<'a, A> {
         );
         let context = Box::new(AgentRuntimeContext::new(runtime_tx));
 
-        let agent_init = agent.run(route, agent_config, context);
+        let agent_init = agent.run(route, route_params, agent_config, context);
 
         async move {
             let agent_init_task = async move {
@@ -486,6 +491,7 @@ impl<'a, A: Agent + 'static> AgentRouteTask<'a, A> {
             agent,
             identity,
             route,
+            route_params,
             attachment_rx,
             downlink_tx,
             stopping,
@@ -499,7 +505,7 @@ impl<'a, A: Agent + 'static> AgentRouteTask<'a, A> {
 
         let context = Box::new(AgentRuntimeContext::new(runtime_tx));
 
-        let agent_init = agent.run(route, agent_config, context);
+        let agent_init = agent.run(route, route_params, agent_config, context);
 
         async move {
             let store = store_fut.await?;

--- a/server/swim_agent/src/agent_lifecycle/item_event/command/tests.rs
+++ b/server/swim_agent/src/agent_lifecycle/item_event/command/tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use parking_lot::Mutex;
 use swim_api::agent::AgentConfig;
@@ -122,13 +122,17 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 #[test]
 fn command_lane_leaf() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -152,7 +156,8 @@ fn command_lane_leaf() {
 #[test]
 fn command_lane_left_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -202,7 +207,8 @@ fn command_lane_left_branch() {
 #[test]
 fn command_lane_right_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -252,7 +258,8 @@ fn command_lane_right_branch() {
 #[test]
 fn command_lane_two_branches() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 

--- a/server/swim_agent/src/agent_lifecycle/item_event/map/tests.rs
+++ b/server/swim_agent/src/agent_lifecycle/item_event/map/tests.rs
@@ -308,14 +308,18 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 #[test]
 fn map_lane_leaf() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -344,7 +348,8 @@ fn map_lane_leaf() {
 #[test]
 fn map_lane_left_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::with_content();
 
@@ -401,7 +406,8 @@ fn map_lane_left_branch() {
 #[test]
 fn map_lane_right_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::with_content();
 
@@ -458,7 +464,8 @@ fn map_lane_right_branch() {
 #[test]
 fn map_lane_two_branches() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::with_content();
 

--- a/server/swim_agent/src/agent_lifecycle/item_event/value/tests.rs
+++ b/server/swim_agent/src/agent_lifecycle/item_event/value/tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use parking_lot::Mutex;
 use swim_api::agent::AgentConfig;
@@ -181,14 +181,18 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 #[test]
 fn value_lane_leaf() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -214,7 +218,8 @@ fn value_lane_leaf() {
 #[test]
 fn value_lane_left_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -266,7 +271,8 @@ fn value_lane_left_branch() {
 #[test]
 fn value_lane_right_branch() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 
@@ -317,7 +323,8 @@ fn value_lane_right_branch() {
 #[test]
 fn value_lane_two_branches() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let agent = TestAgent::default();
 

--- a/server/swim_agent/src/agent_lifecycle/utility/mod.rs
+++ b/server/swim_agent/src/agent_lifecycle/utility/mod.rs
@@ -31,7 +31,7 @@ use crate::config::{MapDownlinkConfig, SimpleDownlinkConfig};
 use crate::downlink_lifecycle::event::EventDownlinkLifecycle;
 use crate::downlink_lifecycle::map::MapDownlinkLifecycle;
 use crate::downlink_lifecycle::value::ValueDownlinkLifecycle;
-use crate::event_handler::{EventHandler, Suspend, UnitHandler};
+use crate::event_handler::{EventHandler, GetParameter, Suspend, UnitHandler};
 use crate::lanes::command::{CommandLane, DoCommand};
 use crate::lanes::join_value::{JoinValueAddDownlink, JoinValueLane};
 use crate::lanes::map::MapLaneGetMap;
@@ -105,6 +105,16 @@ impl<Agent: 'static> HandlerContext<Agent> {
         &self,
     ) -> impl HandlerAction<Agent, Completion = RouteUri> + Send + 'static {
         GetAgentUri::default()
+    }
+
+    /// Get the value of a parameter extracted from the route URI of the agent instance.
+    /// #Arguments
+    /// * `name` - The name of the parameter.
+    pub fn get_parameter<'a>(
+        &self,
+        name: &'a str,
+    ) -> impl HandlerAction<Agent, Completion = Option<String>> + Send + 'a {
+        GetParameter::new(name)
     }
 
     /// Create an event handler that will get the value of a value lane of the agent.

--- a/server/swim_agent/src/agent_model/downlink/hosted/mod.rs
+++ b/server/swim_agent/src/agent_model/downlink/hosted/mod.rs
@@ -109,13 +109,17 @@ mod test_support {
         RouteUri::try_from(NODE_URI).expect("Bad URI.")
     }
 
-    fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-        AgentMetadata::new(uri, &CONFIG)
+    fn make_meta<'a>(
+        uri: &'a RouteUri,
+        route_params: &'a HashMap<String, String>,
+    ) -> AgentMetadata<'a> {
+        AgentMetadata::new(uri, route_params, &CONFIG)
     }
 
     pub fn run_handler<FakeAgent>(mut handler: BoxEventHandler<'_, FakeAgent>, agent: &FakeAgent) {
         let uri = make_uri();
-        let meta = make_meta(&uri);
+        let route_params = HashMap::new();
+        let meta = make_meta(&uri, &route_params);
         let no_spawn = NoSpawn;
         let no_runtime = NoAgentRuntime;
         let mut join_value_init = HashMap::new();

--- a/server/swim_agent/src/agent_model/downlink/tests.rs
+++ b/server/swim_agent/src/agent_model/downlink/tests.rs
@@ -145,8 +145,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 async fn run_all_and_check(
@@ -198,7 +201,8 @@ where
 #[tokio::test]
 async fn open_value_downlink() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut join_value_init = HashMap::new();
     let lifecycle = StatefulValueDownlinkLifecycle::<TestAgent, _, i32>::new(());
 
@@ -223,7 +227,8 @@ async fn open_value_downlink() {
 #[tokio::test]
 async fn open_map_downlink() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut join_value_init = HashMap::new();
     let lifecycle = StatefulMapDownlinkLifecycle::<TestAgent, _, i32, Text>::new(());
 

--- a/server/swim_agent/src/agent_model/mod.rs
+++ b/server/swim_agent/src/agent_model/mod.rs
@@ -253,11 +253,12 @@ where
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult> {
         self.clone()
-            .initialize_agent(route, config, context)
+            .initialize_agent(route, route_params, config, context)
             .boxed()
     }
 }
@@ -358,11 +359,13 @@ where
     ///
     /// #Arguments
     /// * `route` - The node URI for the agent instance.
+    /// * `route_params` - Parameters extracted from the route URI.
     /// * `config` - Agent specific configuration parameters.
     /// * `context` - Context through which to communicate with the runtime.
     async fn initialize_agent(
         self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> AgentInitResult
@@ -375,7 +378,7 @@ where
             lifecycle,
         } = self;
 
-        let meta = AgentMetadata::new(&route, &config);
+        let meta = AgentMetadata::new(&route, &route_params, &config);
 
         let mut value_like_lane_io = HashMap::new();
         let mut map_lane_io = HashMap::new();
@@ -537,6 +540,7 @@ where
             item_model,
             lifecycle,
             route,
+            route_params,
             config,
             item_ids,
             value_like_lane_io,
@@ -555,6 +559,7 @@ struct AgentTask<ItemModel, Lifecycle> {
     item_model: ItemModel,
     lifecycle: Lifecycle,
     route: RouteUri,
+    route_params: HashMap<String, String>,
     config: AgentConfig,
     item_ids: HashMap<u64, Text>,
     value_like_lane_io: HashMap<Text, (ByteWriter, ByteReader)>,
@@ -584,6 +589,7 @@ where
             item_model,
             lifecycle,
             route,
+            route_params,
             config,
             item_ids,
             value_like_lane_io,
@@ -594,7 +600,7 @@ where
             mut join_value_init,
             downlink_channels,
         } = self;
-        let meta = AgentMetadata::new(&route, &config);
+        let meta = AgentMetadata::new(&route, &route_params, &config);
 
         let mut item_ids_rev = HashMap::new();
         for (id, name) in &item_ids {

--- a/server/swim_agent/src/agent_model/tests/mod.rs
+++ b/server/swim_agent/src/agent_model/tests/mod.rs
@@ -1,4 +1,4 @@
-use std::{io::ErrorKind, sync::Arc};
+use std::{collections::HashMap, io::ErrorKind, sync::Arc};
 
 // Copyright 2015-2023 Swim Inc.
 //
@@ -119,7 +119,7 @@ async fn init_agent(context: Box<TestAgentContext>) -> (AgentTask, TestContext) 
     let model = AgentModel::<TestAgent, TestLifecycle>::new(lane_model_fac, lifecycle);
 
     let task = model
-        .initialize_agent(make_uri(), CONFIG, context.clone())
+        .initialize_agent(make_uri(), HashMap::new(), CONFIG, context.clone())
         .await
         .expect("Initialization failed.");
 

--- a/server/swim_agent/src/agent_model/tests/run_handler.rs
+++ b/server/swim_agent/src/agent_model/tests/run_handler.rs
@@ -197,13 +197,17 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 fn run_test_handler(agent: &TestAgent, lifecycle: TestLifecycle, start_with: Lane) -> HashSet<u64> {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut lanes = HashMap::new();
     lanes.insert(Lane::A.id(), Text::new(Lane::A.name()));
     lanes.insert(Lane::B.id(), Text::new(Lane::B.name()));

--- a/server/swim_agent/src/event_handler/mod.rs
+++ b/server/swim_agent/src/event_handler/mod.rs
@@ -886,6 +886,35 @@ impl<Context> HandlerAction<Context> for GetAgentUri {
     }
 }
 
+/// Get a parameter from the route URI of the running agent.
+pub struct GetParameter<S> {
+    key: Option<S>,
+}
+
+impl<S> GetParameter<S> {
+    pub fn new(key: S) -> Self {
+        GetParameter { key: Some(key) }
+    }
+}
+
+impl<Context, S: AsRef<str>> HandlerAction<Context> for GetParameter<S> {
+    type Completion = Option<String>;
+
+    fn step(
+        &mut self,
+        _action_context: &mut ActionContext<Context>,
+        meta: AgentMetadata,
+        _context: &Context,
+    ) -> StepResult<Self::Completion> {
+        let GetParameter { key } = self;
+        if let Some(key) = key.take() {
+            StepResult::done(meta.get_param(key.as_ref()).map(ToString::to_string))
+        } else {
+            StepResult::after_done()
+        }
+    }
+}
+
 /// An event handler that will attempt to decode a [`StructuralReadable`] type from a buffer, immediately
 /// returning the result or an error.
 pub struct Decode<T> {

--- a/server/swim_agent/src/event_handler/suspend/tests.rs
+++ b/server/swim_agent/src/event_handler/suspend/tests.rs
@@ -33,8 +33,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct NoSpawn;
@@ -50,7 +53,8 @@ struct DummyAgent;
 #[tokio::test]
 async fn suspend_future() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut join_value_init = HashMap::new();
 
     let (tx, mut rx) = mpsc::channel(4);

--- a/server/swim_agent/src/event_handler/tests.rs
+++ b/server/swim_agent/src/event_handler/tests.rs
@@ -41,8 +41,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct NoSpawn;
@@ -60,7 +63,8 @@ const DUMMY: DummyAgent = DummyAgent;
 #[test]
 fn side_effect_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut n = 0;
     let mut handler = SideEffect::from(|| n += 1);
@@ -85,7 +89,8 @@ fn side_effect_handler() {
 #[test]
 fn side_effects_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let values = vec![0, 1, 2, 3];
 
@@ -134,7 +139,8 @@ fn side_effects_handler() {
 #[test]
 fn constant_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut handler = ConstHandler::from(5);
     let result = handler.step(&mut dummy_context(&mut HashMap::new()), meta, &DUMMY);
@@ -156,7 +162,8 @@ fn constant_handler() {
 #[test]
 fn get_agent_uri() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut handler = GetAgentUri::default();
     let result = handler.step(&mut dummy_context(&mut HashMap::new()), meta, &DUMMY);
@@ -180,7 +187,8 @@ fn get_agent_uri() {
 #[test]
 fn map_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut handler =
         HandlerActionExt::<DummyAgent>::map(GetAgentUri::default(), move |uri: RouteUri| {
             uri.to_string()
@@ -207,7 +215,8 @@ fn map_handler() {
 #[test]
 fn and_then_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut output = None;
     let output_ref = &mut output;
@@ -247,7 +256,8 @@ fn and_then_handler() {
 #[test]
 fn and_then_contextual_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut output = None;
     let output_ref = &mut output;
@@ -289,7 +299,8 @@ fn and_then_contextual_handler() {
 #[test]
 fn followed_by_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let output = RefCell::new(None);
 
@@ -342,7 +353,8 @@ fn followed_by_handler() {
 #[test]
 fn decoding_handler_success() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut buffer = BytesMut::new();
     write!(buffer, "56").expect("Write failed.");
@@ -368,7 +380,8 @@ fn decoding_handler_success() {
 #[test]
 fn decoding_handler_failure() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut buffer = BytesMut::new();
     write!(buffer, "boom").expect("Write failed.");
@@ -420,7 +433,8 @@ impl HandlerAction<DummyAgent> for FakeLaneWriter {
 #[test]
 fn and_then_handler_with_lane_write() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut handler = FakeLaneWriter::new(7).and_then(|_| ConstHandler::from(34));
     let result = handler.step(&mut dummy_context(&mut HashMap::new()), meta, &DUMMY);
@@ -453,7 +467,8 @@ fn and_then_handler_with_lane_write() {
 #[test]
 fn followed_by_handler_with_lane_write() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let mut handler = FakeLaneWriter::new(7).followed_by(FakeLaneWriter::new(8));
     let result = handler.step(&mut dummy_context(&mut HashMap::new()), meta, &DUMMY);
@@ -506,7 +521,8 @@ fn event_handler_error_display() {
 #[test]
 fn sequentially_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     let values = RefCell::new(vec![]);
 

--- a/server/swim_agent/src/lanes/command/tests.rs
+++ b/server/swim_agent/src/lanes/command/tests.rs
@@ -84,8 +84,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -107,7 +110,8 @@ impl TestAgent {
 #[test]
 fn command_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = DoCommand::new(TestAgent::LANE, 546);

--- a/server/swim_agent/src/lanes/join_value/downlink/tests.rs
+++ b/server/swim_agent/src/lanes/join_value/downlink/tests.rs
@@ -215,8 +215,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 fn run_handler<H>(mut handler: H, meta: AgentMetadata<'_>, agent: &TestAgent) -> Vec<Modification>
@@ -266,7 +269,8 @@ fn set_state_for(
 #[test]
 fn run_on_linked() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     let lifecycle = TestLifecycle::new(Default::default());
     let downlink_lifecycle = JoinValueDownlink::new(TestAgent::LANE, 4, make_address(), lifecycle);
@@ -287,7 +291,8 @@ fn run_on_linked() {
 #[test]
 fn run_on_event() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     let lifecycle = TestLifecycle::new(Default::default());
     let downlink_lifecycle = JoinValueDownlink::new(TestAgent::LANE, 4, make_address(), lifecycle);
@@ -316,7 +321,8 @@ fn run_on_event() {
 #[test]
 fn run_on_unlinked_abandon() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     set_state_for(
         &agent.lane,
@@ -346,7 +352,8 @@ fn run_on_unlinked_abandon() {
 #[test]
 fn run_on_unlinked_delete() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     set_state_for(
         &agent.lane,
@@ -388,7 +395,8 @@ fn run_on_unlinked_delete() {
 #[test]
 fn run_on_failed_abandon() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     set_state_for(
         &agent.lane,
@@ -418,7 +426,8 @@ fn run_on_failed_abandon() {
 #[test]
 fn run_on_failed_delete() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     set_state_for(
         &agent.lane,
@@ -448,7 +457,8 @@ fn run_on_failed_delete() {
 #[test]
 fn run_on_synced() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
     set_state_for(
         &agent.lane,

--- a/server/swim_agent/src/lanes/join_value/init/tests.rs
+++ b/server/swim_agent/src/lanes/join_value/init/tests.rs
@@ -104,8 +104,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 #[tokio::test]
@@ -127,7 +130,8 @@ async fn successfully_create_action() {
 
     let agent = TestAgent::default();
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut inits = HashMap::new();
 
     run_with_futures(&context, &context, &agent, meta, &mut inits, handler).await;

--- a/server/swim_agent/src/lanes/join_value/tests.rs
+++ b/server/swim_agent/src/lanes/join_value/tests.rs
@@ -107,8 +107,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -163,7 +166,8 @@ fn check_result<T: Eq + Debug>(
 #[test]
 fn join_value_lane_get_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = JoinValueLaneGet::new(TestAgent::LANE, K1);
@@ -186,7 +190,8 @@ fn join_value_lane_get_event_handler() {
 #[test]
 fn join_value_lane_get_map_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = JoinValueLaneGetMap::new(TestAgent::LANE);
@@ -300,7 +305,8 @@ const REMOTE_LANE: &str = "remote_lane";
 #[tokio::test]
 async fn join_value_lane_add_downlinks_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let address = Address::text(None, REMOTE_NODE, REMOTE_LANE);
@@ -362,7 +368,8 @@ fn register_lifecycle(
 #[tokio::test]
 async fn open_downlink_from_registered() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let address = Address::text(None, REMOTE_NODE, REMOTE_LANE);

--- a/server/swim_agent/src/lanes/map/tests.rs
+++ b/server/swim_agent/src/lanes/map/tests.rs
@@ -466,8 +466,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -539,7 +542,8 @@ fn check_result<T: Eq + Debug>(
 #[test]
 fn map_lane_update_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = MapLaneUpdate::new(TestAgent::LANE, K1, Text::new(V1));
@@ -562,7 +566,8 @@ fn map_lane_update_event_handler() {
 #[test]
 fn map_lane_remove_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapLaneRemove::new(TestAgent::LANE, K1);
@@ -586,7 +591,8 @@ fn map_lane_remove_event_handler() {
 #[test]
 fn map_lane_clear_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapLaneClear::new(TestAgent::LANE);
@@ -608,7 +614,8 @@ fn map_lane_clear_event_handler() {
 #[test]
 fn map_lane_get_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapLaneGet::new(TestAgent::LANE, K1);
@@ -631,7 +638,8 @@ fn map_lane_get_event_handler() {
 #[test]
 fn map_lane_get_map_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapLaneGetMap::new(TestAgent::LANE);
@@ -651,7 +659,8 @@ fn map_lane_get_map_event_handler() {
 #[test]
 fn map_lane_sync_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapLaneSync::new(TestAgent::LANE, SYNC_ID1);

--- a/server/swim_agent/src/lanes/value/tests.rs
+++ b/server/swim_agent/src/lanes/value/tests.rs
@@ -268,8 +268,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -328,7 +331,8 @@ fn check_result<T: Eq + Debug>(
 #[test]
 fn value_lane_set_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = ValueLaneSet::new(TestAgent::LANE, 84);
@@ -349,7 +353,8 @@ fn value_lane_set_event_handler() {
 #[test]
 fn value_lane_get_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = ValueLaneGet::new(TestAgent::LANE);
@@ -367,7 +372,8 @@ fn value_lane_get_event_handler() {
 #[test]
 fn value_lane_sync_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = ValueLaneSync::new(TestAgent::LANE, SYNC_ID1);

--- a/server/swim_agent/src/meta.rs
+++ b/server/swim_agent/src/meta.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use swim_api::agent::AgentConfig;
 use swim_utilities::routing::route_uri::RouteUri;
 
@@ -20,20 +22,31 @@ use swim_utilities::routing::route_uri::RouteUri;
 pub struct AgentMetadata<'a> {
     // The URI of the instance.
     path: &'a RouteUri,
+    // Parameters extracted from the route URI.
+    route_params: &'a HashMap<String, String>,
     // Specific configuration for the instance.
     configuration: &'a AgentConfig,
 }
 
 impl<'a> AgentMetadata<'a> {
-    pub fn new(path: &'a RouteUri, configuration: &'a AgentConfig) -> Self {
+    pub fn new(
+        path: &'a RouteUri,
+        route_params: &'a HashMap<String, String>,
+        configuration: &'a AgentConfig,
+    ) -> Self {
         AgentMetadata {
             path,
+            route_params,
             configuration,
         }
     }
 
     pub fn agent_uri(&self) -> &'a RouteUri {
         self.path
+    }
+
+    pub fn get_param(&self, name: &str) -> Option<&'a str> {
+        self.route_params.get(name).map(String::as_str)
     }
 
     pub fn agent_configuration(&self) -> &'a AgentConfig {

--- a/server/swim_agent/src/stores/map/tests.rs
+++ b/server/swim_agent/src/stores/map/tests.rs
@@ -331,8 +331,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -404,7 +407,8 @@ fn check_result<T: Eq + Debug>(
 #[test]
 fn map_store_update_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = MapStoreUpdate::new(TestAgent::LANE, K1, Text::new(V1));
@@ -427,7 +431,8 @@ fn map_store_update_event_handler() {
 #[test]
 fn map_store_remove_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapStoreRemove::new(TestAgent::LANE, K1);
@@ -451,7 +456,8 @@ fn map_store_remove_event_handler() {
 #[test]
 fn map_store_clear_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapStoreClear::new(TestAgent::LANE);
@@ -473,7 +479,8 @@ fn map_store_clear_event_handler() {
 #[test]
 fn map_store_get_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapStoreGet::new(TestAgent::LANE, K1);
@@ -496,7 +503,8 @@ fn map_store_get_event_handler() {
 #[test]
 fn map_store_get_map_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::with_init();
 
     let mut handler = MapStoreGetMap::new(TestAgent::LANE);

--- a/server/swim_agent/src/stores/value/tests.rs
+++ b/server/swim_agent/src/stores/value/tests.rs
@@ -108,8 +108,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 struct TestAgent {
@@ -168,7 +171,8 @@ fn check_result<T: Eq + Debug>(
 #[test]
 fn value_store_set_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = ValueStoreSet::new(TestAgent::STORE, 84);
@@ -189,7 +193,8 @@ fn value_store_set_event_handler() {
 #[test]
 fn value_store_get_event_handler() {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let agent = TestAgent::default();
 
     let mut handler = ValueStoreGet::new(TestAgent::STORE);

--- a/server/swim_introspection/src/meta_agent/lane/mod.rs
+++ b/server/swim_introspection/src/meta_agent/lane/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use futures::{future::BoxFuture, FutureExt};
 use swim_api::{
@@ -30,11 +30,11 @@ use swim_utilities::{
 use crate::{
     config::IntrospectionConfig,
     model::LaneView,
-    route::{lane_pattern, LANE_PARAM, NODE_PARAM},
+    route::{LANE_PARAM, NODE_PARAM},
     task::IntrospectionResolver,
 };
 
-use super::{run_pulse_lane, PULSE_LANE};
+use super::{run_pulse_lane, MetaRouteError, PULSE_LANE};
 
 #[cfg(test)]
 mod tests;
@@ -58,6 +58,7 @@ impl Agent for LaneMetaAgent {
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         agent_config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult> {
@@ -66,6 +67,7 @@ impl Agent for LaneMetaAgent {
             config.node_pulse_interval,
             resolver.clone(),
             route,
+            route_params,
             agent_config,
             context,
         )
@@ -77,20 +79,26 @@ async fn run_init(
     pulse_interval: Duration,
     resolver: IntrospectionResolver,
     route: RouteUri,
+    route_params: HashMap<String, String>,
     config: AgentConfig,
     context: Box<dyn AgentContext + Send>,
 ) -> AgentInitResult {
-    let pattern = lane_pattern();
-    let params = match pattern.unapply_route_uri(&route) {
-        Ok(params) => params,
-        Err(e) => return Err(AgentInitError::UserCodeError(Box::new(e))),
+    let node_uri = if let Some(node_uri) = route_params.get(NODE_PARAM) {
+        Text::new(node_uri)
+    } else {
+        return Err(AgentInitError::UserCodeError(Box::new(
+            MetaRouteError::new(route, NODE_PARAM),
+        )));
     };
-    let node_uri = &params[NODE_PARAM];
-    let lane_name = &params[LANE_PARAM];
-    let view = match resolver
-        .resolve_lane(Text::new(node_uri), Text::new(lane_name))
-        .await
-    {
+    let lane_name = if let Some(lane_name) = route_params.get(LANE_PARAM) {
+        Text::new(lane_name)
+    } else {
+        return Err(AgentInitError::UserCodeError(Box::new(
+            MetaRouteError::new(route, LANE_PARAM),
+        )));
+    };
+
+    let view = match resolver.resolve_lane(node_uri, lane_name).await {
         Ok(view) => view,
         Err(e) => return Err(AgentInitError::UserCodeError(Box::new(e))),
     };

--- a/server/swim_introspection/src/meta_agent/lane/tests.rs
+++ b/server/swim_introspection/src/meta_agent/lane/tests.rs
@@ -19,6 +19,7 @@ use crate::{
         PULSE_LANE,
     },
     model::LaneView,
+    route::{LANE_PARAM, NODE_PARAM},
     task::IntrospectionMessage,
 };
 use futures::StreamExt;
@@ -47,12 +48,19 @@ async fn run_lane_meta_agent() {
     let route = "swim:meta:node/%2Fnode/lane/my_lane"
         .parse()
         .expect("Invalid route.");
+    let route_params = [
+        (NODE_PARAM.to_string(), "/node".to_string()),
+        (LANE_PARAM.to_string(), "my_lane".to_string()),
+    ]
+    .into_iter()
+    .collect();
 
     let lanes = vec![(PULSE_LANE.to_string(), LaneKind::Supply)];
     introspection_agent_test(
         expected_lane_config,
         lanes,
         route,
+        route_params,
         |resolver| LaneMetaAgent::new(IntrospectionConfig::default(), resolver),
         |context| async move {
             let IntrospectionTestContext {

--- a/server/swim_introspection/src/meta_agent/mod.rs
+++ b/server/swim_introspection/src/meta_agent/mod.rs
@@ -27,8 +27,10 @@ use swim_form::structural::write::StructuralWritable;
 use swim_runtime::agent::reporting::UplinkReportReader;
 use swim_utilities::{
     io::byte_channel::{ByteReader, ByteWriter},
+    routing::route_uri::RouteUri,
     trigger,
 };
+use thiserror::Error;
 use tokio::time::{Instant, Sleep};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
@@ -151,6 +153,22 @@ where
                 }
             }
             _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Invalid introspection URI: {route}. Missing parameter: {missing}")]
+struct MetaRouteError {
+    route: RouteUri,
+    missing: String,
+}
+
+impl MetaRouteError {
+    pub fn new(route: RouteUri, missing: &str) -> Self {
+        MetaRouteError {
+            route,
+            missing: missing.to_string(),
         }
     }
 }

--- a/server/swim_introspection/src/meta_agent/node/tests.rs
+++ b/server/swim_introspection/src/meta_agent/node/tests.rs
@@ -45,6 +45,7 @@ use crate::{
         PULSE_LANE,
     },
     model::AgentIntrospectionUpdater,
+    route::NODE_PARAM,
     task::IntrospectionMessage,
 };
 
@@ -250,10 +251,15 @@ async fn node_meta_agent_pulse_lane() {
         (LANES_LANE.to_string(), LaneKind::DemandMap),
     ];
 
+    let route_params = [(NODE_PARAM.to_string(), "/node".to_string())]
+        .into_iter()
+        .collect();
+
     introspection_agent_test(
         expected_lane_config,
         lanes,
         route,
+        route_params,
         |resolver| NodeMetaAgent::new(IntrospectionConfig::default(), resolver),
         |context| async move {
             let IntrospectionTestContext {
@@ -301,10 +307,15 @@ async fn node_meta_agent_laneinfo_lane() {
         (LANES_LANE.to_string(), LaneKind::DemandMap),
     ];
 
+    let route_params = [(NODE_PARAM.to_string(), "/node".to_string())]
+        .into_iter()
+        .collect();
+
     introspection_agent_test(
         expected_lane_config,
         lanes,
         route,
+        route_params,
         |resolver| NodeMetaAgent::new(IntrospectionConfig::default(), resolver),
         |context| async move {
             let IntrospectionTestContext {

--- a/server/swim_introspection/src/meta_agent/test_harness.rs
+++ b/server/swim_introspection/src/meta_agent/test_harness.rs
@@ -41,6 +41,7 @@ pub async fn introspection_agent_test<Fac, A, F, Fut>(
     lane_config: LaneConfig,
     lanes: Vec<(String, LaneKind)>,
     route: RouteUri,
+    route_params: HashMap<String, String>,
     agent_fac: Fac,
     test_case: F,
 ) -> Fut::Output
@@ -66,7 +67,7 @@ where
     let agent_task = async move {
         let agent = agent_fac(resolver);
         let run_agent = agent
-            .run(route, config, context)
+            .run(route, route_params, config, context)
             .await
             .expect("Init failed.");
         init_tx.trigger();

--- a/server/swim_server_app/src/plane.rs
+++ b/server/swim_server_app/src/plane.rs
@@ -129,6 +129,8 @@ impl PlaneBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use futures::future::BoxFuture;
     use swim_api::agent::{Agent, AgentConfig, AgentContext, AgentInitResult};
     use swim_utilities::routing::{route_pattern::RoutePattern, route_uri::RouteUri};
@@ -143,6 +145,7 @@ mod tests {
         fn run(
             &self,
             _route: RouteUri,
+            _route_params: HashMap<String, String>,
             _config: AgentConfig,
             _context: Box<dyn AgentContext + Send>,
         ) -> BoxFuture<'static, AgentInitResult> {

--- a/server/swim_server_app/src/server/runtime/mod.rs
+++ b/server/swim_server_app/src/server/runtime/mod.rs
@@ -724,13 +724,14 @@ impl Agents {
             }
             Entry::Vacant(entry) => {
                 debug!("Attempting to start new agent instance.");
-                if let Some((route_uri, route)) = RouteUri::from_str(entry.key().as_str())
-                    .ok()
-                    .and_then(|route_uri| {
-                        routes
-                            .find_route(&route_uri)
-                            .map(move |route| (route_uri, route))
-                    })
+                if let Some((route_uri, (route, route_params))) =
+                    RouteUri::from_str(entry.key().as_str())
+                        .ok()
+                        .and_then(|route_uri| {
+                            routes
+                                .find_route(&route_uri)
+                                .map(move |route| (route_uri, route))
+                        })
                 {
                     let id = plane_issuer.next_id();
                     let (attachment_tx, attachment_rx) =
@@ -761,6 +762,7 @@ impl Agents {
                         AgentRoute {
                             identity: id,
                             route: route_uri,
+                            route_params,
                         },
                         attachment_rx,
                         open_dl_tx.clone(),
@@ -833,11 +835,15 @@ impl Routes {
         routes.push(Route::new(route_pattern, Box::new(agent), true));
     }
 
-    fn find_route<'a>(&'a self, node: &RouteUri) -> Option<&'a Route> {
+    fn find_route<'a>(&'a self, node: &RouteUri) -> Option<(&'a Route, HashMap<String, String>)> {
         let Routes(routes) = self;
-        routes
-            .iter()
-            .find(|Route { pattern, .. }| pattern.unapply_route_uri(node).is_ok())
+        routes.iter().find_map(|route| {
+            route
+                .pattern
+                .unapply_route_uri(node)
+                .ok()
+                .map(move |route_params| (route, route_params))
+        })
     }
 }
 

--- a/server/swim_server_app/src/server/runtime/tests/agent.rs
+++ b/server/swim_server_app/src/server/runtime/tests/agent.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use bytes::BytesMut;
 use futures::{future::BoxFuture, pin_mut, stream::unfold, FutureExt, SinkExt, Stream, StreamExt};
 use swim_api::{
@@ -55,14 +57,14 @@ pub enum AgentEvent {
 pub struct TestAgent {
     reporter: mpsc::UnboundedSender<i32>,
     events: mpsc::UnboundedSender<AgentEvent>,
-    check_meta: fn(RouteUri, AgentConfig),
+    check_meta: fn(RouteUri, HashMap<String, String>, AgentConfig),
 }
 
 impl TestAgent {
     pub fn new(
         reporter: mpsc::UnboundedSender<i32>, //Reports each time the state changes.
         events: mpsc::UnboundedSender<AgentEvent>, //Reports when the agent is started or stopped.
-        check_meta: fn(RouteUri, AgentConfig), //Check to perform on the agent metadata on startup.
+        check_meta: fn(RouteUri, HashMap<String, String>, AgentConfig), //Check to perform on the agent metadata on startup.
     ) -> Self {
         TestAgent {
             reporter,
@@ -76,10 +78,11 @@ impl Agent for TestAgent {
     fn run(
         &self,
         route: RouteUri,
+        route_params: HashMap<String, String>,
         config: AgentConfig,
         context: Box<dyn AgentContext + Send>,
     ) -> BoxFuture<'static, AgentInitResult> {
-        (self.check_meta)(route, config);
+        (self.check_meta)(route, route_params, config);
         let events = self.events.clone();
         let reporter = self.reporter.clone();
         async move {

--- a/server/swim_server_app/src/server/runtime/tests/mod.rs
+++ b/server/swim_server_app/src/server/runtime/tests/mod.rs
@@ -113,7 +113,7 @@ where
 
     plane_builder.add_route(
         pattern,
-        TestAgent::new(report_tx, event_tx, |uri, _conf| {
+        TestAgent::new(report_tx, event_tx, |uri, _route_params, _conf| {
             assert_eq!(uri, "/node");
         }),
     );

--- a/swim/tests/agentlifecycle.rs
+++ b/swim/tests/agentlifecycle.rs
@@ -185,8 +185,11 @@ fn make_uri() -> RouteUri {
     RouteUri::try_from(NODE_URI).expect("Bad URI.")
 }
 
-fn make_meta(uri: &RouteUri) -> AgentMetadata<'_> {
-    AgentMetadata::new(uri, &CONFIG)
+fn make_meta<'a>(
+    uri: &'a RouteUri,
+    route_params: &'a HashMap<String, String>,
+) -> AgentMetadata<'a> {
+    AgentMetadata::new(uri, route_params, &CONFIG)
 }
 
 fn run_handler_mod<Agent, H: EventHandler<Agent>>(
@@ -195,7 +198,8 @@ fn run_handler_mod<Agent, H: EventHandler<Agent>>(
     modified: Option<u64>,
 ) {
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
     let mut join_value_init = HashMap::new();
     loop {
         match handler.step(&mut dummy_context(&mut join_value_init), meta, agent) {
@@ -1410,7 +1414,8 @@ fn register_join_value_lifecycle() {
     let mut join_value_init = HashMap::new();
     let mut action_context = dummy_context(&mut join_value_init);
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     lifecycle.initialize(&mut action_context, meta, &agent);
 
@@ -1459,7 +1464,8 @@ fn register_two_join_value_lifecycles() {
     let mut join_value_init = HashMap::new();
     let mut action_context = dummy_context(&mut join_value_init);
     let uri = make_uri();
-    let meta = make_meta(&uri);
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
 
     lifecycle.initialize(&mut action_context, meta, &agent);
 

--- a/swim_utilities/swim_route/src/route_pattern/mod.rs
+++ b/swim_utilities/swim_route/src/route_pattern/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 Swim Inc.
+// Copyright 2015-2021 Swim Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The parameters extracted from the agent route are now passed as a `HashMap<String, String>` into the agent and can be accessd in event handlers through the agent metadata.