### PR TITLE
Example app for local downlink.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "example_apps/event_downlink",
     "example_apps/value_downlink",
     "example_apps/map_downlink",
+    "example_apps/local_downlink",
 ]
 
 exclude = [

--- a/example_apps/local_downlink/Cargo.toml
+++ b/example_apps/local_downlink/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "local-downlink"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+swim = { path = "../../swim", features = ["server", "agent"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
+example-util = { path = "../example_util" }

--- a/example_apps/local_downlink/src/consumer/agent.rs
+++ b/example_apps/local_downlink/src/consumer/agent.rs
@@ -1,0 +1,145 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use swim::agent::{
+    agent_lifecycle::utility::HandlerContext,
+    agent_model::downlink::hosted::ValueDownlinkHandle,
+    event_handler::{EventHandler, HandlerAction, HandlerActionExt},
+    lanes::{CommandLane, ValueLane},
+    lifecycle, projections,
+    state::State,
+    AgentLaneModel,
+};
+
+use super::model::Instruction;
+
+#[derive(AgentLaneModel)]
+#[projections]
+pub struct ConsumerAgent {
+    lane: ValueLane<i32>,
+    instruct: CommandLane<Instruction>,
+}
+
+pub struct ConsumerLifecycle {
+    handle: State<ConsumerAgent, Option<ValueDownlinkHandle<i32>>>,
+}
+
+impl ConsumerLifecycle {
+    pub fn new() -> Self {
+        ConsumerLifecycle {
+            handle: State::default(),
+        }
+    }
+}
+
+#[lifecycle(ConsumerAgent, no_clone)]
+impl ConsumerLifecycle {
+    #[on_start]
+    pub fn on_start(
+        &self,
+        context: HandlerContext<ConsumerAgent>,
+    ) -> impl EventHandler<ConsumerAgent> {
+        context.get_agent_uri().and_then(move |uri| {
+            context.effect(move || {
+                println!("Starting consumer agent at: {}", uri);
+            })
+        })
+    }
+
+    #[on_stop]
+    pub fn on_stop(
+        &self,
+        context: HandlerContext<ConsumerAgent>,
+    ) -> impl EventHandler<ConsumerAgent> {
+        context.get_agent_uri().and_then(move |uri| {
+            context.effect(move || {
+                println!("Stopping consumer agent at: {}", uri);
+            })
+        })
+    }
+
+    #[on_event(lane)]
+    pub fn on_event(
+        &self,
+        context: HandlerContext<ConsumerAgent>,
+        value: &i32,
+    ) -> impl EventHandler<ConsumerAgent> {
+        let n = *value;
+        context.effect(move || {
+            println!("Setting value on consumer to: {}", n);
+        })
+    }
+
+    #[on_command(instruct)]
+    pub fn instruct<'a>(
+        &'a self,
+        context: HandlerContext<ConsumerAgent>,
+        command: &Instruction,
+    ) -> impl EventHandler<ConsumerAgent> + 'a {
+        let ConsumerLifecycle { handle } = self;
+        let msg = format!("Handling: {:?}", command);
+        let handle_instr = match *command {
+            Instruction::OpenLink => handle
+                .and_then_with(move |maybe| match maybe {
+                    Some(dl_handle) if !dl_handle.is_stopped() => None,
+                    _ => Some(
+                        open_link(context).and_then(move |dl_handle| handle.set(Some(dl_handle))),
+                    ),
+                })
+                .discard()
+                .boxed(),
+            Instruction::CloseLink => handle
+                .with_mut(|h| {
+                    if let Some(h) = h.as_mut() {
+                        h.stop();
+                    }
+                })
+                .boxed(),
+            Instruction::Send(n) => handle
+                .with_mut(move |maybe| {
+                    if let Some(handle) = maybe.as_mut() {
+                        if handle.set(n).is_err() {
+                            *maybe = None;
+                        }
+                    }
+                })
+                .boxed(),
+            Instruction::Stop => context.stop().boxed(),
+        };
+        context
+            .effect(move || println!("{}", msg))
+            .followed_by(handle_instr)
+    }
+}
+
+fn open_link(
+    context: HandlerContext<ConsumerAgent>,
+) -> impl HandlerAction<ConsumerAgent, Completion = ValueDownlinkHandle<i32>> {
+    context
+        .value_downlink_builder(None, "/producer/a", "lane", Default::default())
+        .on_linked(|context| context.effect(|| println!("Link opened.")))
+        .on_synced(|context, v| {
+            let value = *v;
+            context.effect(move || println!("Link synchronized: {}", value))
+        })
+        .on_event(|context, v| {
+            context.value(*v).and_then(move |v| {
+                println!("Received value on link: {}", v);
+                context.set_value(ConsumerAgent::LANE, v)
+            })
+        })
+        .on_unlinked(|context| context.effect(|| println!("Link closed.")))
+        .on_failed(|context| context.effect(|| println!("Link failed.")))
+        .done()
+}

--- a/example_apps/local_downlink/src/consumer/mod.rs
+++ b/example_apps/local_downlink/src/consumer/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod agent;
+mod model;

--- a/example_apps/local_downlink/src/consumer/model.rs
+++ b/example_apps/local_downlink/src/consumer/model.rs
@@ -1,0 +1,27 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use swim::form::Form;
+
+#[derive(Debug, Clone, Copy, Form)]
+pub enum Instruction {
+    #[form(tag = "open_link")]
+    OpenLink,
+    #[form(tag = "close_link")]
+    CloseLink,
+    #[form(tag = "send")]
+    Send(#[form(header_body)] i32),
+    #[form(tag = "stop")]
+    Stop,
+}

--- a/example_apps/local_downlink/src/main.rs
+++ b/example_apps/local_downlink/src/main.rs
@@ -1,0 +1,62 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error::Error, time::Duration};
+
+use example_util::{example_logging, manage_handle};
+use swim::{
+    agent::agent_model::AgentModel,
+    route::RoutePattern,
+    server::{Server, ServerBuilder},
+};
+
+use crate::{
+    consumer::agent::{ConsumerAgent, ConsumerLifecycle},
+    producer::agent::{ProducerAgent, ProducerLifecycle},
+};
+
+mod consumer;
+mod producer;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    example_logging()?;
+
+    let producer_route = RoutePattern::parse_str("/producer/:name}")?;
+    let consumer_route = RoutePattern::parse_str("/consumer/:name}")?;
+
+    let producer_lifecycle = ProducerLifecycle;
+    let consumer_lifecycle_fn = || ConsumerLifecycle::new().into_lifecycle();
+    let producer = AgentModel::new(ProducerAgent::default, producer_lifecycle.into_lifecycle());
+    let consumer = AgentModel::from_fn(ConsumerAgent::default, consumer_lifecycle_fn);
+
+    let server = ServerBuilder::with_plane_name("Example Plane")
+        .add_route(producer_route, producer)
+        .add_route(consumer_route, consumer)
+        .update_config(|config| {
+            config.agent_runtime.inactive_timeout = Duration::from_secs(5 * 60);
+        })
+        .build()
+        .await?;
+
+    let (task, handle) = server.run();
+
+    let shutdown = manage_handle(handle);
+
+    let (_, result) = tokio::join!(shutdown, task);
+
+    result?;
+    println!("Server stopped successfully.");
+    Ok(())
+}

--- a/example_apps/local_downlink/src/producer/agent.rs
+++ b/example_apps/local_downlink/src/producer/agent.rs
@@ -1,0 +1,68 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use swim::agent::{
+    agent_lifecycle::utility::HandlerContext,
+    event_handler::{EventHandler, HandlerActionExt},
+    lanes::ValueLane,
+    lifecycle, projections, AgentLaneModel,
+};
+
+#[derive(AgentLaneModel)]
+#[projections]
+pub struct ProducerAgent {
+    lane: ValueLane<i32>,
+}
+
+#[derive(Clone)]
+pub struct ProducerLifecycle;
+
+#[lifecycle(ProducerAgent)]
+impl ProducerLifecycle {
+    #[on_start]
+    pub fn on_start(
+        &self,
+        context: HandlerContext<ProducerAgent>,
+    ) -> impl EventHandler<ProducerAgent> {
+        context.get_agent_uri().and_then(move |uri| {
+            context.effect(move || {
+                println!("Starting producer agent at: {}", uri);
+            })
+        })
+    }
+
+    #[on_stop]
+    pub fn on_stop(
+        &self,
+        context: HandlerContext<ProducerAgent>,
+    ) -> impl EventHandler<ProducerAgent> {
+        context.get_agent_uri().and_then(move |uri| {
+            context.effect(move || {
+                println!("Stopping producer agent at: {}", uri);
+            })
+        })
+    }
+
+    #[on_event(lane)]
+    pub fn on_event(
+        &self,
+        context: HandlerContext<ProducerAgent>,
+        value: &i32,
+    ) -> impl EventHandler<ProducerAgent> {
+        let n = *value;
+        context.effect(move || {
+            println!("Setting value on producer to: {}", n);
+        })
+    }
+}

--- a/example_apps/local_downlink/src/producer/mod.rs
+++ b/example_apps/local_downlink/src/producer/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2015-2023 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod agent;

--- a/server/swim_agent/src/agent_model/mod.rs
+++ b/server/swim_agent/src/agent_model/mod.rs
@@ -207,7 +207,7 @@ where
     }
 }
 
-trait LifecycleFac<ItemModel>: Send + Sync {
+pub trait LifecycleFac<ItemModel>: Send + Sync {
     type LifecycleType: AgentLifecycle<ItemModel> + Send;
 
     fn create(&self) -> Self::LifecycleType;


### PR DESCRIPTION
The same as the `value_downlink` example except both agents are in the same plane.