### PR TITLE
Renamed modifier attribute from "lane" to "item".

### DIFF
--- a/docs/define.md
+++ b/docs/define.md
@@ -120,7 +120,7 @@ of time. To achieve this using the derive macro, a tag can be added to the lane 
 ```rust
 #[derive(AgentLaneModel)]
 struct ExampleAgent {
-    #[lane(transient)]
+    #[item(transient)]
     value_lane: ValueLane<i32>,
     map_lane: MapLane<String, u64>,
 }

--- a/example_apps/map_lane_persistence/src/agent.rs
+++ b/example_apps/map_lane_persistence/src/agent.rs
@@ -24,7 +24,7 @@ use swimos::agent::{
 #[projections]
 pub struct ExampleAgent {
     map: MapLane<String, i32>,
-    #[lane(transient)]
+    #[item(transient)]
     temporary: MapLane<String, i32>,
     stop: CommandLane<()>,
 }

--- a/example_apps/map_store/src/agent.rs
+++ b/example_apps/map_store/src/agent.rs
@@ -27,7 +27,7 @@ use crate::model::Instruction;
 #[projections]
 pub struct ExampleAgent {
     lane: ValueLane<i32>,
-    #[lane(transient)]
+    #[item(transient)]
     saved: MapStore<String, i32>,
     command: CommandLane<Instruction>,
 }

--- a/example_apps/map_store_persistence/src/agent.rs
+++ b/example_apps/map_store_persistence/src/agent.rs
@@ -28,7 +28,7 @@ use crate::model::Instruction;
 #[projections]
 pub struct ExampleAgent {
     value: MapStore<String, i32>,
-    #[lane(transient)]
+    #[item(transient)]
     temporary: MapStore<String, i32>,
     instructions: CommandLane<Instruction>,
 }

--- a/example_apps/tutorial_app/src/unit_agent.rs
+++ b/example_apps/tutorial_app/src/unit_agent.rs
@@ -31,7 +31,7 @@ use tutorial_app_model::{Counter, HistoryItem, Message};
 pub struct UnitAgent {
     publish: CommandLane<Message>,
     history: MapLane<usize, HistoryItem>,
-    #[lane(transient)]
+    #[item(transient)]
     histogram: MapLane<i64, Counter>,
     latest: ValueLane<Option<Message>>,
 }

--- a/example_apps/value_lane_persistence/src/agent.rs
+++ b/example_apps/value_lane_persistence/src/agent.rs
@@ -23,7 +23,7 @@ use swimos::agent::{
 #[projections]
 pub struct ExampleAgent {
     value: ValueLane<i32>,
-    #[lane(transient)]
+    #[item(transient)]
     temporary: ValueLane<i32>,
     stop: CommandLane<()>,
 }

--- a/example_apps/value_store/src/agent.rs
+++ b/example_apps/value_store/src/agent.rs
@@ -27,7 +27,7 @@ use crate::model::Instruction;
 #[projections]
 pub struct ExampleAgent {
     lane: ValueLane<i32>,
-    #[lane(transient)]
+    #[item(transient)]
     saved: ValueStore<i32>,
     command: CommandLane<Instruction>,
 }

--- a/example_apps/value_store_persistence/src/agent.rs
+++ b/example_apps/value_store_persistence/src/agent.rs
@@ -27,7 +27,7 @@ use crate::model::Instruction;
 #[projections]
 pub struct ExampleAgent {
     value: ValueStore<i32>,
-    #[lane(transient)]
+    #[item(transient)]
     temporary: ValueStore<i32>,
     instructions: CommandLane<Instruction>,
 }

--- a/server/swimos_agent_derive/src/lane_model_derive/model.rs
+++ b/server/swimos_agent_derive/src/lane_model_derive/model.rs
@@ -356,7 +356,7 @@ const SUPPLY_LANE_NAME: &str = "SupplyLane";
 const HTTP_LANE_NAME: &str = "HttpLane";
 const SIMPLE_HTTP_LANE_NAME: &str = "SimpleHttpLane";
 
-const LANE_TAG: &str = "lane";
+const ITEM_TAG: &str = "item";
 
 fn extract_lane_model(field: &Field) -> Validation<ItemModel<'_>, Errors<syn::Error>> {
     if let (Some(fld_name), Type::Path(TypePath { qself: None, path })) = (&field.ident, &field.ty)
@@ -364,7 +364,7 @@ fn extract_lane_model(field: &Field) -> Validation<ItemModel<'_>, Errors<syn::Er
         if let Some(PathSegment { ident, arguments }) = path.segments.last() {
             let type_name = ident.to_string();
             let (item_attrs, errors) =
-                consume_attributes(LANE_TAG, &field.attrs, make_item_attr_consumer());
+                consume_attributes(ITEM_TAG, &field.attrs, make_item_attr_consumer());
             let modifiers = Validation::Validated(item_attrs, Errors::from(errors))
                 .and_then(|item_attrs| combine_item_attrs(field, item_attrs));
 

--- a/server/swimos_agent_derive/src/lib.rs
+++ b/server/swimos_agent_derive/src/lib.rs
@@ -32,7 +32,7 @@ fn default_root() -> syn::Path {
 
 const AGENT_TAG: &str = "agent";
 
-#[proc_macro_derive(AgentLaneModel, attributes(agent, lane))]
+#[proc_macro_derive(AgentLaneModel, attributes(agent, item))]
 pub fn derive_agent_lane_model(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let (item_attrs, errors) =

--- a/swimos/src/agent.rs
+++ b/swimos/src/agent.rs
@@ -198,7 +198,7 @@ pub use swimos_agent_derive::{lifecycle, projections, AgentLaneModel};
 ///
 /// #[derive(AgentLaneModel)]
 /// struct TransientAgent {
-///     #[lane(transient)]
+///     #[item(transient)]
 ///     value_lane: ValueLane<i32>,
 /// }
 /// ```

--- a/swimos/tests/bad_agents/duplicate_names.rs
+++ b/swimos/tests/bad_agents/duplicate_names.rs
@@ -18,7 +18,7 @@ use swimos::agent::AgentLaneModel;
 #[derive(AgentLaneModel)]
 #[allow(non_snake_case)]
 pub struct RenameConvention {
-    #[lane(convention = "camel")]
+    #[item(convention = "camel")]
     first_lane: ValueLane<i32>,
     firstLane: ValueLane<i32>,
 }

--- a/swimos/tests/bad_agents/duplicate_names.stderr
+++ b/swimos/tests/bad_agents/duplicate_names.stderr
@@ -3,7 +3,7 @@ error: Agent item names must be unique. Duplicated names: [firstLane]
    |
 19 | / #[allow(non_snake_case)]
 20 | | pub struct RenameConvention {
-21 | |     #[lane(convention = "camel")]
+21 | |     #[item(convention = "camel")]
 22 | |     first_lane: ValueLane<i32>,
 23 | |     firstLane: ValueLane<i32>,
 24 | | }

--- a/swimos/tests/deriveagentlanemodel.rs
+++ b/swimos/tests/deriveagentlanemodel.rs
@@ -433,7 +433,7 @@ fn stores_and_lanes() {
 fn value_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoValueLanes {
-        #[lane(transient)]
+        #[item(transient)]
         first: ValueLane<i32>,
         second: ValueLane<i32>,
     }
@@ -448,7 +448,7 @@ fn value_lane_tagged_transient() {
 fn value_store_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoValueStores {
-        #[lane(transient)]
+        #[item(transient)]
         first: ValueStore<i32>,
         second: ValueStore<i32>,
     }
@@ -464,7 +464,7 @@ fn map_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoMapLanes {
         first: MapLane<i32, i32>,
-        #[lane(transient)]
+        #[item(transient)]
         second: MapLane<i32, i32>,
     }
 
@@ -479,7 +479,7 @@ fn map_store_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoMapStores {
         first: MapStore<i32, i32>,
-        #[lane(transient)]
+        #[item(transient)]
         second: MapStore<i32, i32>,
     }
 
@@ -493,7 +493,7 @@ fn map_store_tagged_transient() {
 fn command_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoCommandLanes {
-        #[lane(transient)]
+        #[item(transient)]
         first: CommandLane<i32>,
         second: CommandLane<i32>,
     }
@@ -508,7 +508,7 @@ fn command_lane_tagged_transient() {
 fn demand_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoDemandLanes {
-        #[lane(transient)]
+        #[item(transient)]
         first: DemandLane<i32>,
         second: DemandLane<i32>,
     }
@@ -523,7 +523,7 @@ fn demand_lane_tagged_transient() {
 fn supply_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoSupplyLanes {
-        #[lane(transient)]
+        #[item(transient)]
         first: SupplyLane<i32>,
         second: SupplyLane<i32>,
     }
@@ -538,7 +538,7 @@ fn supply_lane_tagged_transient() {
 fn demand_map_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoDemandMapLanes {
-        #[lane(transient)]
+        #[item(transient)]
         first: DemandMapLane<i32, i32>,
         second: DemandMapLane<i32, i32>,
     }
@@ -578,7 +578,7 @@ fn join_value_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoJoinValueLanes {
         first: JoinValueLane<i32, i32>,
-        #[lane(transient)]
+        #[item(transient)]
         second: JoinValueLane<i32, i32>,
     }
 
@@ -617,7 +617,7 @@ fn join_map_lane_tagged_transient() {
     #[derive(AgentLaneModel)]
     struct TwoJoinMapLanes {
         first: JoinMapLane<i32, i32, i32>,
-        #[lane(transient)]
+        #[item(transient)]
         second: JoinMapLane<i32, i32, i32>,
     }
 
@@ -764,7 +764,7 @@ fn two_types_single_scope() {
 fn rename_lane() {
     #[derive(AgentLaneModel)]
     struct RenameExplicit {
-        #[lane(name = "renamed")]
+        #[item(name = "renamed")]
         first: ValueLane<i32>,
         second: ValueLane<i32>,
     }
@@ -779,7 +779,7 @@ fn rename_lane() {
 fn rename_lane_with_convention() {
     #[derive(AgentLaneModel)]
     struct RenameConvention {
-        #[lane(convention = "camel")]
+        #[item(convention = "camel")]
         first_lane: ValueLane<i32>,
         second_lane: ValueLane<i32>,
     }
@@ -813,7 +813,7 @@ fn override_top_level_convention() {
     #[agent(convention = "camel")]
     struct OverrideRename {
         first_lane: ValueLane<i32>,
-        #[lane(name = "renamed")]
+        #[item(name = "renamed")]
         second_lane: ValueLane<i32>,
         third_lane: ValueLane<i32>,
     }


### PR DESCRIPTION
Currently, it is necssary to use the `#[lane(..)] attribute to apply modifiers to both lanes and stores. This changes to attribute to be `#[item(...)]` for both cases. Fixes #605.