### PR TITLE
Adds an `on_timer` event to agents.

### DIFF
--- a/server/swimos_agent/src/agent_lifecycle/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/mod.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use self::{item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop};
+use self::{
+    item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop, on_timer::OnTimer,
+};
 
 #[doc(hidden)]
 pub mod item_event;
@@ -27,6 +29,7 @@ pub mod on_start;
 /// after execution of this handler stops. The signature of the event is described by the
 /// [`on_stop::OnStop`] trait.
 pub mod on_stop;
+pub mod on_timer;
 mod stateful;
 mod utility;
 
@@ -35,12 +38,12 @@ mod utility;
 /// # Type Parameters
 /// * `Context` - The context in which the lifecycle events run (provides access to the lanes of the agent).
 pub trait AgentLifecycle<Context>:
-    OnInit<Context> + OnStart<Context> + OnStop<Context> + ItemEvent<Context>
+    OnInit<Context> + OnStart<Context> + OnStop<Context> + OnTimer<Context> + ItemEvent<Context>
 {
 }
 
 impl<L, Context> AgentLifecycle<Context> for L where
-    L: OnInit<Context> + OnStart<Context> + OnStop<Context> + ItemEvent<Context>
+    L: OnInit<Context> + OnStart<Context> + OnStop<Context> + OnTimer<Context> + ItemEvent<Context>
 {
 }
 

--- a/server/swimos_agent/src/agent_lifecycle/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/mod.rs
@@ -29,6 +29,8 @@ pub mod on_start;
 /// after execution of this handler stops. The signature of the event is described by the
 /// [`on_stop::OnStop`] trait.
 pub mod on_stop;
+/// The `on_timer` event handler is executed each time a timeout (that was requested by the agent lifecycle)
+/// completes. The signature of this event is described by the [`on_timer::OnTimer`] trait.
 pub mod on_timer;
 mod stateful;
 mod utility;

--- a/server/swimos_agent/src/agent_lifecycle/on_timer.rs
+++ b/server/swimos_agent/src/agent_lifecycle/on_timer.rs
@@ -1,0 +1,96 @@
+// Copyright 2015-2024 Swim Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use swimos_utilities::handlers::{FnHandler, NoHandler};
+
+use crate::event_handler::{EventConsumeFn, EventHandler, UnitHandler};
+
+use super::utility::HandlerContext;
+
+/// Lifecycle event for the `on_timer` event of an agent.
+pub trait OnTimer<Context>: Send {
+    fn on_timer(&self, timer_id: u64) -> impl EventHandler<Context> + '_;
+}
+
+/// Lifecycle event for the `on_timer` event of an agent where the event handler
+/// has shared state with other handlers for the same agent.
+pub trait OnTimerShared<Context, Shared>: Send {
+    type OnTimerHandler<'a>: EventHandler<Context> + 'a
+    where
+        Self: 'a,
+        Shared: 'a;
+
+    /// # Arguments
+    /// * `shared` - The shared state.
+    /// * `handler_context` - Utility for constructing event handlers.
+    fn on_timer<'a>(
+        &'a self,
+        shared: &'a Shared,
+        handler_context: HandlerContext<Context>,
+        timer_id: u64,
+    ) -> Self::OnTimerHandler<'a>;
+}
+
+impl<Context> OnTimer<Context> for NoHandler {
+    fn on_timer(&self, _timer_id: u64) -> impl EventHandler<Context> + '_ {
+        UnitHandler::default()
+    }
+}
+
+impl<Context, F, H> OnTimer<Context> for FnHandler<F>
+where
+    F: Fn(u64) -> H + Send,
+    H: EventHandler<Context> + 'static,
+{
+    fn on_timer(&self, timer_id: u64) -> impl EventHandler<Context> + '_ {
+        let FnHandler(f) = self;
+        f(timer_id)
+    }
+}
+
+impl<Context, Shared> OnTimerShared<Context, Shared> for NoHandler {
+    type OnTimerHandler<'a> = UnitHandler
+    where
+        Self: 'a,
+        Shared: 'a;
+
+    fn on_timer<'a>(
+        &'a self,
+        _shared: &'a Shared,
+        _handler_context: HandlerContext<Context>,
+        _timer_id: u64,
+    ) -> Self::OnTimerHandler<'a> {
+        Default::default()
+    }
+}
+
+impl<Context, Shared, F> OnTimerShared<Context, Shared> for FnHandler<F>
+where
+    F: for<'a> EventConsumeFn<'a, Context, Shared, u64> + Send,
+{
+    type OnTimerHandler<'a> = <F as EventConsumeFn<'a, Context, Shared, u64>>::Handler
+    where
+        Self: 'a,
+        Shared: 'a;
+
+    fn on_timer<'a>(
+        &'a self,
+        shared: &'a Shared,
+        handler_context: HandlerContext<Context>,
+        timer_id: u64,
+    ) -> Self::OnTimerHandler<'a> {
+        let FnHandler(f) = self;
+        f.make_handler(shared, handler_context, timer_id)
+    }
+}

--- a/server/swimos_agent/src/agent_lifecycle/on_timer.rs
+++ b/server/swimos_agent/src/agent_lifecycle/on_timer.rs
@@ -20,6 +20,8 @@ use super::utility::HandlerContext;
 
 /// Lifecycle event for the `on_timer` event of an agent.
 pub trait OnTimer<Context>: Send {
+    /// # Arguments
+    /// * `timer_id` - An arbitrary ID to distinguish between different timer events.
     fn on_timer(&self, timer_id: u64) -> impl EventHandler<Context> + '_;
 }
 
@@ -34,6 +36,7 @@ pub trait OnTimerShared<Context, Shared>: Send {
     /// # Arguments
     /// * `shared` - The shared state.
     /// * `handler_context` - Utility for constructing event handlers.
+    /// * `timer_id` - An arbitrary ID to distinguish between different timer events.
     fn on_timer<'a>(
         &'a self,
         shared: &'a Shared,

--- a/server/swimos_agent/src/agent_lifecycle/stateful/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/stateful/mod.rs
@@ -26,6 +26,7 @@ use super::{
     on_init::{OnInit, OnInitShared},
     on_start::{OnStart, OnStartShared},
     on_stop::{OnStop, OnStopShared},
+    on_timer::{OnTimer, OnTimerShared},
     utility::HandlerContext,
 };
 
@@ -45,6 +46,7 @@ pub struct StatefulAgentLifecycle<
     FInit = NoHandler,
     FStart = NoHandler,
     FStop = NoHandler,
+    FTime = NoHandler,
     ItemEv = NoHandler,
 > {
     state: State,
@@ -52,11 +54,19 @@ pub struct StatefulAgentLifecycle<
     on_init: FInit,
     on_start: FStart,
     on_stop: FStop,
+    on_timer: FTime,
     item_event: ItemEv,
 }
 
-impl<Context, State: Clone, FInit: Clone, FStart: Clone, FStop: Clone, ItemEv: Clone> Clone
-    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<
+        Context,
+        State: Clone,
+        FInit: Clone,
+        FStart: Clone,
+        FStop: Clone,
+        FTime: Clone,
+        ItemEv: Clone,
+    > Clone for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 {
     fn clone(&self) -> Self {
         Self {
@@ -65,6 +75,7 @@ impl<Context, State: Clone, FInit: Clone, FStart: Clone, FStop: Clone, ItemEv: C
             on_init: self.on_init.clone(),
             on_start: self.on_start.clone(),
             on_stop: self.on_stop.clone(),
+            on_timer: self.on_timer.clone(),
             item_event: self.item_event.clone(),
         }
     }
@@ -80,18 +91,20 @@ impl<Context, State> StatefulAgentLifecycle<Context, State> {
             on_init: NoHandler,
             on_start: NoHandler,
             on_stop: NoHandler,
+            on_timer: NoHandler,
             item_event: NoHandler,
         }
     }
 }
 
-impl<FInit, FStart, FStop, ItemEv, Context, State> OnInit<Context>
-    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<FInit, FStart, FStop, FTime, ItemEv, Context, State> OnInit<Context>
+    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 where
     State: Send,
     FInit: OnInitShared<Context, State>,
     FStart: Send,
     FStop: Send,
+    FTime: Send,
     ItemEv: Send,
 {
     fn initialize(
@@ -105,13 +118,14 @@ where
     }
 }
 
-impl<FInit, FStart, FStop, ItemEv, Context, State> OnStart<Context>
-    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<FInit, FStart, FStop, FTime, ItemEv, Context, State> OnStart<Context>
+    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 where
     State: Send,
     FInit: Send,
     FStart: OnStartShared<Context, State>,
     FStop: Send,
+    FTime: Send,
     ItemEv: Send,
 {
     fn on_start(&self) -> impl EventHandler<Context> + '_ {
@@ -125,13 +139,14 @@ where
     }
 }
 
-impl<FInit, FStart, FStop, ItemEv, Context, State> OnStop<Context>
-    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<FInit, FStart, FStop, FTime, ItemEv, Context, State> OnStop<Context>
+    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 where
     State: Send,
     FInit: Send,
     FStop: OnStopShared<Context, State>,
     FStart: Send,
+    FTime: Send,
     ItemEv: Send,
 {
     fn on_stop(&self) -> impl EventHandler<Context> + '_ {
@@ -145,13 +160,35 @@ where
     }
 }
 
-impl<FInit, FStart, FStop, ItemEv, Context, State> ItemEvent<Context>
-    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<FInit, FStart, FStop, FTime, ItemEv, Context, State> OnTimer<Context>
+    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
+where
+    State: Send,
+    FInit: Send,
+    FStop: Send,
+    FStart: Send,
+    FTime: OnTimerShared<Context, State>,
+    ItemEv: Send,
+{
+    fn on_timer(&self, timer_id: u64) -> impl EventHandler<Context> + '_ {
+        let StatefulAgentLifecycle {
+            state,
+            handler_context,
+            on_timer,
+            ..
+        } = self;
+        on_timer.on_timer(state, *handler_context, timer_id)
+    }
+}
+
+impl<FInit, FStart, FStop, FTime, ItemEv, Context, State> ItemEvent<Context>
+    for StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 where
     FInit: Send,
     State: Send,
     FStart: Send,
     FStop: Send,
+    FTime: Send,
     ItemEv: ItemEventShared<Context, State>,
 {
     type ItemEventHandler<'a> = ItemEv::ItemEventHandler<'a>
@@ -173,14 +210,14 @@ where
     }
 }
 
-impl<Context, State, FInit, FStart, FStop, ItemEv>
-    StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, ItemEv>
+impl<Context, State, FInit, FStart, FStop, FTime, ItemEv>
+    StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, ItemEv>
 {
     /// Replace the `on_start` handler with another defined using a closure.
     pub fn on_init<H>(
         self,
         handler: H,
-    ) -> StatefulAgentLifecycle<Context, State, H, FStart, FStop, ItemEv>
+    ) -> StatefulAgentLifecycle<Context, State, H, FStart, FStop, FTime, ItemEv>
     where
         H: OnInitShared<Context, State>,
     {
@@ -189,6 +226,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             state,
             on_start,
             on_stop,
+            on_timer,
             item_event,
             ..
         } = self;
@@ -198,6 +236,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             on_init: handler,
             on_start,
             on_stop,
+            on_timer,
             item_event,
         }
     }
@@ -206,7 +245,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
     pub fn on_start<F>(
         self,
         f: F,
-    ) -> StatefulAgentLifecycle<Context, State, FInit, FnHandler<F>, FStop, ItemEv>
+    ) -> StatefulAgentLifecycle<Context, State, FInit, FnHandler<F>, FStop, FTime, ItemEv>
     where
         FnHandler<F>: OnStartShared<Context, State>,
     {
@@ -215,6 +254,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             state,
             on_init,
             on_stop,
+            on_timer,
             item_event,
             ..
         } = self;
@@ -224,6 +264,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             on_init,
             on_start: FnHandler(f),
             on_stop,
+            on_timer,
             item_event,
         }
     }
@@ -232,7 +273,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
     pub fn on_stop<F>(
         self,
         f: F,
-    ) -> StatefulAgentLifecycle<Context, State, FInit, FStart, FnHandler<F>, ItemEv>
+    ) -> StatefulAgentLifecycle<Context, State, FInit, FStart, FnHandler<F>, FTime, ItemEv>
     where
         FnHandler<F>: OnStopShared<Context, State>,
     {
@@ -241,6 +282,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             state,
             on_init,
             on_start,
+            on_timer,
             item_event,
             ..
         } = self;
@@ -250,6 +292,35 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             on_init,
             on_start,
             on_stop: FnHandler(f),
+            on_timer,
+            item_event,
+        }
+    }
+
+    /// Replace the `on_timer` handler with another defined using a closure.
+    pub fn on_timer<F>(
+        self,
+        f: F,
+    ) -> StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FnHandler<F>, ItemEv>
+    where
+        FnHandler<F>: OnTimerShared<Context, State>,
+    {
+        let StatefulAgentLifecycle {
+            handler_context,
+            state,
+            on_init,
+            on_start,
+            on_stop,
+            item_event,
+            ..
+        } = self;
+        StatefulAgentLifecycle {
+            handler_context,
+            state,
+            on_init,
+            on_start,
+            on_stop,
+            on_timer: FnHandler(f),
             item_event,
         }
     }
@@ -258,7 +329,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
     pub fn on_lane_event<H>(
         self,
         handler: H,
-    ) -> StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, H>
+    ) -> StatefulAgentLifecycle<Context, State, FInit, FStart, FStop, FTime, H>
     where
         H: ItemEventShared<Context, State>,
     {
@@ -268,6 +339,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             on_init,
             on_start,
             on_stop,
+            on_timer,
             ..
         } = self;
         StatefulAgentLifecycle {
@@ -276,6 +348,7 @@ impl<Context, State, FInit, FStart, FStop, ItemEv>
             on_init,
             on_start,
             on_stop,
+            on_timer,
             item_event: handler,
         }
     }

--- a/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
@@ -40,7 +40,7 @@ use crate::downlink_lifecycle::ValueDownlinkLifecycle;
 use crate::downlink_lifecycle::{EventDownlinkLifecycle, MapDownlinkLifecycle};
 use crate::event_handler::{
     run_after, run_schedule, run_schedule_async, ConstHandler, EventHandler, Fail, GetParameter,
-    HandlerActionExt, ScheduleTimeout, SendCommand, Sequentially, Stop, Suspend, UnitHandler,
+    HandlerActionExt, ScheduleTimerEvent, SendCommand, Sequentially, Stop, Suspend, UnitHandler,
 };
 use crate::event_handler::{GetAgentUri, HandlerAction, SideEffect};
 use crate::item::{
@@ -915,32 +915,36 @@ impl<Agent: 'static> HandlerContext<Agent> {
         OpenLane::new(name.to_string(), WarpLaneKind::Map, on_done)
     }
 
-    /// Schedule the agent's `on_timeout` event to be called at some time in the future.
+    /// Schedule the agent's `on_timer` event to be called at some time in the future. This can be used as an
+    /// alternative to suspending a future where the resulting handler needs to have access to the agent
+    /// lifecycle (suspending futures must have a static lifetime).
     ///
     /// # Arguments
     /// * `duration` - Duration after the current time for the event to trigger. If this is non-positive, the event
     ///    will be triggered immediately.
     /// * `id` - The ID to pass to the event handler.
-    pub fn schedule_agent_timeout(
+    pub fn schedule_timer_event(
         &self,
         duration: Duration,
         id: u64,
     ) -> impl EventHandler<Agent> + Send + 'static {
-        self.schedule_agent_timeout_at(Instant::now() + duration, id)
+        self.schedule_timer_event_at(Instant::now() + duration, id)
     }
 
-    /// Schedule the agent's `on_timeout` event to be called at some time in the future.
+    /// Schedule the agent's `on_timer` event to be called at some time in the future. This can be used as an
+    /// alternative to suspending a future where the resulting handler needs to have access to the agent
+    /// lifecycle (suspending futures must have a static lifetime).
     ///
     /// # Arguments
     /// * `at` - The time at which to trigger the event handler. If this is in the past, the event will be triggered
     ///   immediately.
     /// * `id` - The ID to pass to the event handler.
-    pub fn schedule_agent_timeout_at(
+    pub fn schedule_timer_event_at(
         &self,
         at: Instant,
         id: u64,
     ) -> impl EventHandler<Agent> + Send + 'static {
-        ScheduleTimeout::new(at, id)
+        ScheduleTimerEvent::new(at, id)
     }
 }
 

--- a/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
@@ -40,7 +40,7 @@ use crate::downlink_lifecycle::ValueDownlinkLifecycle;
 use crate::downlink_lifecycle::{EventDownlinkLifecycle, MapDownlinkLifecycle};
 use crate::event_handler::{
     run_after, run_schedule, run_schedule_async, ConstHandler, EventHandler, Fail, GetParameter,
-    HandlerActionExt, SendCommand, Sequentially, Stop, Suspend, UnitHandler,
+    HandlerActionExt, ScheduleTimeout, SendCommand, Sequentially, Stop, Suspend, UnitHandler,
 };
 use crate::event_handler::{GetAgentUri, HandlerAction, SideEffect};
 use crate::item::{
@@ -913,6 +913,34 @@ impl<Agent: 'static> HandlerContext<Agent> {
         H: EventHandler<Agent> + Send + 'static,
     {
         OpenLane::new(name.to_string(), WarpLaneKind::Map, on_done)
+    }
+
+    /// Schedule the agent's `on_timeout` event to be called at some time in the future.
+    ///
+    /// # Arguments
+    /// * `duration` - Duration after the current time for the event to trigger. If this is non-positive, the event
+    ///    will be triggered immediately.
+    /// * `id` - The ID to pass to the event handler.
+    pub fn schedule_agent_timeout(
+        &self,
+        duration: Duration,
+        id: u64,
+    ) -> impl EventHandler<Agent> + Send + 'static {
+        self.schedule_agent_timeout_at(Instant::now() + duration, id)
+    }
+
+    /// Schedule the agent's `on_timeout` event to be called at some time in the future.
+    ///
+    /// # Arguments
+    /// * `at` - The time at which to trigger the event handler. If this is in the past, the event will be triggered
+    ///   immediately.
+    /// * `id` - The ID to pass to the event handler.
+    pub fn schedule_agent_timeout_at(
+        &self,
+        at: Instant,
+        id: u64,
+    ) -> impl EventHandler<Agent> + Send + 'static {
+        ScheduleTimeout::new(at, id)
     }
 }
 

--- a/server/swimos_agent/src/agent_model/downlink/hosted/mod.rs
+++ b/server/swimos_agent/src/agent_model/downlink/hosted/mod.rs
@@ -178,6 +178,7 @@ mod test_support {
     use swimos_api::{address::Address, agent::AgentConfig};
     use swimos_model::Text;
     use swimos_utilities::routing::RouteUri;
+    use tokio::time::Instant;
 
     use crate::{
         agent_model::downlink::BoxDownlinkChannelFactory,
@@ -194,6 +195,10 @@ mod test_support {
     impl<FakeAgent> Spawner<FakeAgent> for NoSpawn {
         fn spawn_suspend(&self, _fut: HandlerFuture<FakeAgent>) {
             panic!("Unexpected spawn.");
+        }
+
+        fn schedule_timer(&self, _at: Instant, _id: u64) {
+            panic!("Unexpected timer.");
         }
     }
 

--- a/server/swimos_agent/src/agent_model/downlink/tests.rs
+++ b/server/swimos_agent/src/agent_model/downlink/tests.rs
@@ -24,6 +24,7 @@ use swimos_api::{
 };
 use swimos_model::Text;
 use swimos_utilities::routing::RouteUri;
+use tokio::time::Instant;
 
 use crate::{
     agent_model::DownlinkSpawnRequest,
@@ -54,6 +55,10 @@ struct TestSpawner {
 impl Spawner<TestAgent> for TestSpawner {
     fn spawn_suspend(&self, fut: HandlerFuture<TestAgent>) {
         self.futures.push(fut);
+    }
+
+    fn schedule_timer(&self, _at: Instant, _id: u64) {
+        panic!("Unexpected timer.");
     }
 }
 

--- a/server/swimos_agent/src/agent_model/mod.rs
+++ b/server/swimos_agent/src/agent_model/mod.rs
@@ -50,6 +50,7 @@ use swimos_utilities::future::RetryStrategy;
 use swimos_utilities::routing::RouteUri;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
+use tokio::time::{sleep_until, Instant, Sleep};
 use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
@@ -57,7 +58,7 @@ use crate::agent_lifecycle::item_event::ItemEvent;
 use crate::agent_model::io::LaneReadEvent;
 use crate::event_handler::{
     ActionContext, BoxJoinLaneInit, DownlinkSpawnOnDone, DownlinkSpawner, HandlerFuture,
-    LaneSpawnOnDone, LaneSpawner, LocalBoxEventHandler, ModificationFlags, Sequentially,
+    LaneSpawnOnDone, LaneSpawner, LocalBoxEventHandler, ModificationFlags, Sequentially, Spawner,
 };
 use crate::{
     agent_lifecycle::AgentLifecycle,
@@ -423,7 +424,7 @@ enum TaskEvent<ItemModel> {
         result: Result<bool, std::io::Error>,
     },
     SuspendedComplete {
-        handler: LocalBoxEventHandler<'static, ItemModel>,
+        result: SuspendResult<ItemModel>,
     },
     DownlinkReady {
         downlink_event: DownlinksEvent<ItemModel>,
@@ -1027,7 +1028,7 @@ struct AgentTask<ItemModel, Lifecycle> {
     lane_io: HashMap<(Text, WarpLaneKind), (ByteWriter, ByteReader)>,
     store_io: HashMap<Text, ByteWriter>,
     http_lane_rxs: HashMap<Text, mpsc::Receiver<HttpLaneRequest>>,
-    suspended: FuturesUnordered<HandlerFuture<ItemModel>>,
+    suspended: FuturesUnordered<Suspended<ItemModel>>,
     downlink_requests: Vec<DownlinkSpawnRequest<ItemModel>>,
     join_lane_init: HashMap<u64, BoxJoinLaneInit<'static, ItemModel>>,
     ad_hoc_buffer: BytesMut,
@@ -1135,7 +1136,7 @@ where
             let select_event = async {
                 tokio::select! {
                     maybe_suspended = suspended.next(), if !suspended.is_empty() => {
-                        maybe_suspended.map(|handler| TaskEvent::SuspendedComplete { handler })
+                        maybe_suspended.map(|result| TaskEvent::SuspendedComplete { result })
                     }
                     maybe_downlink = downlinks.next(), if !downlinks.is_empty() => {
                         maybe_downlink.map(|downlink_event| TaskEvent::DownlinkReady { downlink_event })
@@ -1246,7 +1247,15 @@ where
                     }
                     item_writers.insert(writer.lane_id(), writer);
                 }
-                TaskEvent::SuspendedComplete { handler } => {
+                TaskEvent::SuspendedComplete {
+                    result: SuspendResult::Handler(handler),
+                } => {
+                    exec_handler!(handler);
+                }
+                TaskEvent::SuspendedComplete {
+                    result: SuspendResult::TimedOut(id),
+                } => {
+                    let handler = lifecycle.on_timer(id);
                     exec_handler!(handler);
                 }
                 TaskEvent::DownlinkReady {
@@ -1937,5 +1946,71 @@ async fn open_with_retry(
     match open_fut.await {
         Ok((tx, rx)) => OpenDownlinkResult::Success(tx, rx),
         Err(err) => OpenDownlinkResult::Failed(err, retry),
+    }
+}
+
+enum SuspendResult<Context> {
+    Handler(LocalBoxEventHandler<'static, Context>),
+    TimedOut(u64),
+}
+
+#[pin_project(project = SuspendedProj)]
+enum Suspended<Context> {
+    Handler(HandlerFuture<Context>),
+    Timeout {
+        #[pin]
+        at: Sleep,
+        id: u64,
+    },
+}
+
+impl<Context> From<HandlerFuture<Context>> for Suspended<Context> {
+    fn from(value: HandlerFuture<Context>) -> Self {
+        Suspended::Handler(value)
+    }
+}
+
+impl<Context> Suspended<Context> {
+    fn timeout(time: Instant, id: u64) -> Self {
+        Suspended::Timeout {
+            at: sleep_until(time),
+            id,
+        }
+    }
+}
+
+impl<Context> Future for Suspended<Context> {
+    type Output = SuspendResult<Context>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            SuspendedProj::Handler(fut) => fut.poll_unpin(cx).map(SuspendResult::Handler),
+            SuspendedProj::Timeout { at, id } => {
+                at.poll(cx).map(move |_| SuspendResult::TimedOut(*id))
+            }
+        }
+    }
+}
+
+impl<F, Context> Spawner<Context> for F
+where
+    F: Fn(Suspended<Context>),
+{
+    fn spawn_suspend(&self, fut: HandlerFuture<Context>) {
+        self(fut.into())
+    }
+
+    fn schedule_timer(&self, at: Instant, id: u64) {
+        self(Suspended::timeout(at, id))
+    }
+}
+
+impl<Context> Spawner<Context> for FuturesUnordered<Suspended<Context>> {
+    fn spawn_suspend(&self, fut: HandlerFuture<Context>) {
+        self.push(fut.into());
+    }
+
+    fn schedule_timer(&self, at: Instant, id: u64) {
+        self.push(Suspended::timeout(at, id))
     }
 }

--- a/server/swimos_agent/src/agent_model/tests/downlinks/start_dl_lifecycle.rs
+++ b/server/swimos_agent/src/agent_model/tests/downlinks/start_dl_lifecycle.rs
@@ -23,7 +23,10 @@ use swimos_model::Text;
 use swimos_utilities::byte_channel::{ByteReader, ByteWriter};
 
 use crate::{
-    agent_lifecycle::{item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop},
+    agent_lifecycle::{
+        item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop,
+        on_timer::OnTimer,
+    },
     agent_model::downlink::{
         BoxDownlinkChannel, DownlinkChannel, DownlinkChannelError, DownlinkChannelEvent,
         DownlinkChannelFactory,
@@ -73,6 +76,12 @@ impl OnStart<EmptyAgent> for StartDownlinkLifecycle {
 
 impl OnStop<EmptyAgent> for StartDownlinkLifecycle {
     fn on_stop(&self) -> impl EventHandler<EmptyAgent> + '_ {
+        UnitHandler::default()
+    }
+}
+
+impl OnTimer<EmptyAgent> for StartDownlinkLifecycle {
+    fn on_timer(&self, _timer_id: u64) -> impl EventHandler<EmptyAgent> + '_ {
         UnitHandler::default()
     }
 }

--- a/server/swimos_agent/src/agent_model/tests/fake_lifecycle.rs
+++ b/server/swimos_agent/src/agent_model/tests/fake_lifecycle.rs
@@ -19,7 +19,8 @@ use tokio::sync::mpsc;
 
 use crate::{
     agent_lifecycle::{
-        item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop, HandlerContext,
+        item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop,
+        on_timer::OnTimer, HandlerContext,
     },
     event_handler::{
         ActionContext, EventHandler, HandlerAction, HandlerActionExt, LocalBoxEventHandler,
@@ -147,6 +148,12 @@ impl OnStart<TestAgent> for TestLifecycle {
 
 impl OnStop<TestAgent> for TestLifecycle {
     fn on_stop(&self) -> impl EventHandler<TestAgent> + '_ {
+        self.make_handler(LifecycleEvent::Stop)
+    }
+}
+
+impl OnTimer<TestAgent> for TestLifecycle {
+    fn on_timer(&self, _timer_id: u64) -> impl EventHandler<TestAgent> + '_ {
         self.make_handler(LifecycleEvent::Stop)
     }
 }

--- a/server/swimos_agent/src/event_handler/mod.rs
+++ b/server/swimos_agent/src/event_handler/mod.rs
@@ -1632,22 +1632,22 @@ where
     }
 }
 
-/// Schedule the agent's `on_timeout` event to be called.
-pub struct ScheduleTimeout {
+/// Schedule the agent's `on_timer` event to be called.
+pub struct ScheduleTimerEvent {
     at: Option<Instant>,
     id: u64,
 }
 
-impl ScheduleTimeout {
+impl ScheduleTimerEvent {
     /// # Arguments
     /// * `at` - The time at which the event should trigger. If this is in the past, the event will trigger immediately.
     /// * `id` - The ID to to be passed to the event handler.
-    pub fn new(at: Instant, id: u64) -> ScheduleTimeout {
-        ScheduleTimeout { at: Some(at), id }
+    pub fn new(at: Instant, id: u64) -> ScheduleTimerEvent {
+        ScheduleTimerEvent { at: Some(at), id }
     }
 }
 
-impl<Context> HandlerAction<Context> for ScheduleTimeout {
+impl<Context> HandlerAction<Context> for ScheduleTimerEvent {
     type Completion = ();
 
     fn step(
@@ -1656,7 +1656,7 @@ impl<Context> HandlerAction<Context> for ScheduleTimeout {
         _meta: AgentMetadata,
         _context: &Context,
     ) -> StepResult<Self::Completion> {
-        let ScheduleTimeout { at, id } = self;
+        let ScheduleTimerEvent { at, id } = self;
         if let Some(t) = at.take() {
             action_context.schedule_timer(t, *id);
             StepResult::done(())

--- a/server/swimos_agent/src/event_handler/mod.rs
+++ b/server/swimos_agent/src/event_handler/mod.rs
@@ -1641,7 +1641,7 @@ pub struct ScheduleTimerEvent {
 impl ScheduleTimerEvent {
     /// # Arguments
     /// * `at` - The time at which the event should trigger. If this is in the past, the event will trigger immediately.
-    /// * `id` - The ID to to be passed to the event handler.
+    /// * `id` - The ID to be passed to the event handler.
     pub fn new(at: Instant, id: u64) -> ScheduleTimerEvent {
         ScheduleTimerEvent { at: Some(at), id }
     }

--- a/server/swimos_agent/src/event_handler/mod.rs
+++ b/server/swimos_agent/src/event_handler/mod.rs
@@ -36,6 +36,7 @@ use swimos_utilities::{
     routing::RouteUri,
 };
 use thiserror::Error;
+use tokio::time::Instant;
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::{
@@ -125,7 +126,11 @@ pub struct ActionContext<'a, Context> {
 
 impl<'a, Context> Spawner<Context> for ActionContext<'a, Context> {
     fn spawn_suspend(&self, fut: HandlerFuture<Context>) {
-        self.spawner.spawn_suspend(fut)
+        self.spawner.spawn_suspend(fut);
+    }
+
+    fn schedule_timer(&self, at: Instant, id: u64) {
+        self.spawner.schedule_timer(at, id);
     }
 }
 
@@ -1621,6 +1626,40 @@ where
     ) -> StepResult<Self::Completion> {
         if let Some(e) = self.error.take() {
             StepResult::Fail(EventHandlerError::EffectError(Box::new(e)))
+        } else {
+            StepResult::after_done()
+        }
+    }
+}
+
+/// Schedule the agent's `on_timeout` event to be called.
+pub struct ScheduleTimeout {
+    at: Option<Instant>,
+    id: u64,
+}
+
+impl ScheduleTimeout {
+    /// # Arguments
+    /// * `at` - The time at which the event should trigger. If this is in the past, the event will trigger immediately.
+    /// * `id` - The ID to to be passed to the event handler.
+    pub fn new(at: Instant, id: u64) -> ScheduleTimeout {
+        ScheduleTimeout { at: Some(at), id }
+    }
+}
+
+impl<Context> HandlerAction<Context> for ScheduleTimeout {
+    type Completion = ();
+
+    fn step(
+        &mut self,
+        action_context: &mut ActionContext<Context>,
+        _meta: AgentMetadata,
+        _context: &Context,
+    ) -> StepResult<Self::Completion> {
+        let ScheduleTimeout { at, id } = self;
+        if let Some(t) = at.take() {
+            action_context.schedule_timer(t, *id);
+            StepResult::done(())
         } else {
             StepResult::after_done()
         }

--- a/server/swimos_agent/src/event_handler/suspend/mod.rs
+++ b/server/swimos_agent/src/event_handler/suspend/mod.rs
@@ -16,10 +16,10 @@ use std::time::Duration;
 
 use futures::{
     future::{BoxFuture, Either},
-    stream::FuturesUnordered,
     Future, FutureExt, Stream, StreamExt,
 };
 use static_assertions::assert_obj_safe;
+use tokio::time::Instant;
 
 use crate::meta::AgentMetadata;
 
@@ -40,24 +40,11 @@ pub trait Spawner<Context> {
     /// result in an event handler that will be executed by the agent task after the
     /// future completes.
     fn spawn_suspend(&self, fut: HandlerFuture<Context>);
-}
 
-impl<F, Context> Spawner<Context> for F
-where
-    F: Fn(HandlerFuture<Context>),
-{
-    fn spawn_suspend(&self, fut: HandlerFuture<Context>) {
-        self(fut)
-    }
+    fn schedule_timer(&self, at: Instant, id: u64);
 }
 
 assert_obj_safe!(Spawner<()>);
-
-impl<Context> Spawner<Context> for FuturesUnordered<HandlerFuture<Context>> {
-    fn spawn_suspend(&self, fut: HandlerFuture<Context>) {
-        self.push(fut);
-    }
-}
 
 /// A handler action that will suspend a future into the agent task.
 pub struct Suspend<Fut> {

--- a/server/swimos_agent/src/event_handler/suspend/tests.rs
+++ b/server/swimos_agent/src/event_handler/suspend/tests.rs
@@ -19,16 +19,16 @@ use crate::{
         ActionContext, EventHandler, EventHandlerError, HandlerAction, SideEffect, StepResult,
     },
     meta::AgentMetadata,
-    test_context::{NO_DOWNLINKS, NO_DYN_LANES},
+    test_context::{TestSpawner, NO_DOWNLINKS, NO_DYN_LANES},
 };
 use bytes::BytesMut;
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::StreamExt;
 use parking_lot::Mutex;
 use swimos_api::agent::AgentConfig;
 use swimos_utilities::{routing::RouteUri, trigger};
 use tokio::{sync::mpsc, time::Instant};
 
-use super::{HandlerFuture, Suspend};
+use super::Suspend;
 
 const CONFIG: AgentConfig = AgentConfig::DEFAULT;
 const NODE_URI: &str = "/node";
@@ -64,7 +64,7 @@ async fn suspend_future() {
         })
     });
 
-    let mut spawner = FuturesUnordered::new();
+    let mut spawner = TestSpawner::<DummyAgent>::default();
 
     let result = suspend.step(
         &mut ActionContext::new(
@@ -135,7 +135,7 @@ async fn suspend_future() {
     .expect("Timed out.");
 }
 
-fn run_handler<H>(mut handler: H, spawner: &FuturesUnordered<HandlerFuture<DummyAgent>>)
+fn run_handler<H>(mut handler: H, spawner: &TestSpawner<DummyAgent>)
 where
     H: EventHandler<DummyAgent>,
 {
@@ -173,7 +173,7 @@ async fn run_handler_with_futures<H>(handler: H)
 where
     H: EventHandler<DummyAgent>,
 {
-    let mut spawner = FuturesUnordered::new();
+    let mut spawner = TestSpawner::default();
     run_handler(handler, &spawner);
 
     if !spawner.is_empty() {

--- a/server/swimos_agent/src/event_handler/tests.rs
+++ b/server/swimos_agent/src/event_handler/tests.rs
@@ -19,10 +19,12 @@ use bytes::BytesMut;
 use swimos_api::agent::AgentConfig;
 use swimos_recon::parser::AsyncParseError;
 use swimos_utilities::routing::RouteUri;
+use tokio::time::Instant;
 
 use crate::event_handler::check_step::{check_is_complete, check_is_continue};
 use crate::event_handler::{GetParameter, ModificationFlags};
 
+use crate::test_context::{NO_DOWNLINKS, NO_DYN_LANES};
 use crate::{
     event_handler::{
         ConstHandler, EventHandlerError, GetAgentUri, HandlerActionExt, Sequentially, SideEffects,
@@ -32,7 +34,10 @@ use crate::{
     test_context::dummy_context,
 };
 
-use super::{join, ActionContext, Decode, HandlerAction, Modification, SideEffect, StepResult};
+use super::{
+    join, ActionContext, Decode, HandlerAction, HandlerFuture, Modification, ScheduleTimeout,
+    SideEffect, Spawner, StepResult,
+};
 
 const CONFIG: AgentConfig = AgentConfig::DEFAULT;
 const NODE_URI: &str = "/node";
@@ -964,4 +969,67 @@ fn join3_handler_modify() {
     agent.lane1.read(|v| assert_eq!(*v, 2));
     agent.lane2.read(|v| assert_eq!(*v, 3));
     agent.lane3.read(|v| assert_eq!(*v, 4));
+}
+
+#[derive(Default)]
+struct TimeoutSpawner {
+    timers: RefCell<Vec<(Instant, u64)>>,
+}
+
+struct TimeoutAgent;
+
+impl Spawner<TimeoutAgent> for TimeoutSpawner {
+    fn spawn_suspend(&self, _fut: HandlerFuture<TimeoutAgent>) {
+        panic!("Unexpected future.");
+    }
+
+    fn schedule_timer(&self, at: Instant, id: u64) {
+        self.timers.borrow_mut().push((at, id));
+    }
+}
+
+impl TimeoutSpawner {
+    fn take(&self) -> Vec<(Instant, u64)> {
+        let mut guard = self.timers.borrow_mut();
+        std::mem::take(&mut *guard)
+    }
+}
+
+#[test]
+fn schedule_timeout() {
+    let mut join_lane_init = HashMap::new();
+    let mut ad_hoc_buffer = BytesMut::new();
+    let uri = make_uri();
+    let route_params = HashMap::new();
+    let meta = make_meta(&uri, &route_params);
+
+    let agent = TimeoutAgent;
+    let spawner = TimeoutSpawner::default();
+
+    let mut action_context = ActionContext::new(
+        &spawner,
+        &NO_DOWNLINKS,
+        &NO_DYN_LANES,
+        &mut join_lane_init,
+        &mut ad_hoc_buffer,
+    );
+
+    let t = Instant::now();
+    let mut handler = ScheduleTimeout::new(t, 3);
+
+    assert!(matches!(
+        handler.step(&mut action_context, meta, &agent),
+        StepResult::Complete {
+            modified_item: None,
+            result: _
+        }
+    ));
+
+    let requests = spawner.take();
+    assert_eq!(requests, vec![(t, 3)]);
+
+    assert!(matches!(
+        handler.step(&mut action_context, meta, &agent),
+        StepResult::Fail(EventHandlerError::SteppedAfterComplete)
+    ));
 }

--- a/server/swimos_agent/src/event_handler/tests.rs
+++ b/server/swimos_agent/src/event_handler/tests.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 use super::{
-    join, ActionContext, Decode, HandlerAction, HandlerFuture, Modification, ScheduleTimeout,
+    join, ActionContext, Decode, HandlerAction, HandlerFuture, Modification, ScheduleTimerEvent,
     SideEffect, Spawner, StepResult,
 };
 
@@ -1015,7 +1015,7 @@ fn schedule_timeout() {
     );
 
     let t = Instant::now();
-    let mut handler = ScheduleTimeout::new(t, 3);
+    let mut handler = ScheduleTimerEvent::new(t, 3);
 
     assert!(matches!(
         handler.step(&mut action_context, meta, &agent),

--- a/server/swimos_agent/src/lanes/join/map/tests.rs
+++ b/server/swimos_agent/src/lanes/join/map/tests.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use futures::stream::FuturesUnordered;
 use swimos_agent_protocol::MapMessage;
 use swimos_api::{
     address::Address,
@@ -35,7 +34,7 @@ use crate::lanes::join_map::{
     AddDownlinkAction, JoinMapAddDownlink, JoinMapLaneGet, JoinMapLaneGetMap, JoinMapLaneWithEntry,
     JoinMapRemoveDownlink,
 };
-use crate::test_context::{dummy_context, run_event_handlers, run_with_futures};
+use crate::test_context::{dummy_context, run_event_handlers, run_with_futures, TestSpawner};
 use crate::test_util::{TestDlContextInner, TestDownlinkContext};
 use crate::{event_handler::StepResult, item::MapItem, meta::AgentMetadata};
 
@@ -234,7 +233,7 @@ async fn join_map_lane_add_downlinks_event_handler() {
     );
 
     let context = TestDownlinkContext::new(DownlinkKind::MapEvent);
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut inits = HashMap::new();
     let mut ad_hoc_buffer = BytesMut::new();
 
@@ -309,7 +308,7 @@ async fn open_downlink_from_registered() {
 
     let count = Arc::new(AtomicUsize::new(0));
 
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut action_context =
         ActionContext::new(&spawner, &context, &context, &mut inits, &mut ad_hoc_buffer);
     register_lifecycle(&mut action_context, &agent, count.clone());
@@ -394,7 +393,7 @@ async fn stop_downlink() {
 
     let count = Arc::new(AtomicUsize::new(0));
 
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut action_context =
         ActionContext::new(&spawner, &context, &context, &mut inits, &mut ad_hoc_buffer);
     register_lifecycle(&mut action_context, &agent, count.clone());

--- a/server/swimos_agent/src/lanes/join/value/tests.rs
+++ b/server/swimos_agent/src/lanes/join/value/tests.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use bytes::BytesMut;
-use futures::stream::FuturesUnordered;
 use swimos_api::{
     address::Address,
     agent::{AgentConfig, DownlinkKind},
@@ -39,7 +38,7 @@ use crate::{
         JoinValueLaneGetMap, JoinValueLaneWithEntry,
     },
     meta::AgentMetadata,
-    test_context::{dummy_context, run_event_handlers, run_with_futures},
+    test_context::{dummy_context, run_event_handlers, run_with_futures, TestSpawner},
 };
 use crate::{
     lanes::join_value::JoinValueRemoveDownlink,
@@ -289,7 +288,7 @@ async fn join_value_lane_add_downlinks_event_handler() {
     );
 
     let context = TestDownlinkContext::default();
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut inits = HashMap::new();
     let mut ad_hoc_buffer = BytesMut::new();
 
@@ -364,7 +363,7 @@ async fn open_downlink_from_registered() {
 
     let count = Arc::new(AtomicUsize::new(0));
 
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut action_context =
         ActionContext::new(&spawner, &context, &context, &mut inits, &mut ad_hoc_buffer);
     register_lifecycle(&mut action_context, &agent, count.clone());
@@ -400,7 +399,7 @@ async fn stop_downlink() {
 
     let count = Arc::new(AtomicUsize::new(0));
 
-    let spawner = FuturesUnordered::new();
+    let spawner = TestSpawner::<TestAgent>::default();
     let mut action_context =
         ActionContext::new(&spawner, &context, &context, &mut inits, &mut ad_hoc_buffer);
     register_lifecycle(&mut action_context, &agent, count.clone());

--- a/server/swimos_agent/src/lanes/tests.rs
+++ b/server/swimos_agent/src/lanes/tests.rs
@@ -57,6 +57,10 @@ impl Spawner<TestAgent> for TestSpawner {
     fn spawn_suspend(&self, _fut: HandlerFuture<TestAgent>) {
         panic!("Suspending futures not supported.");
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer.");
+    }
 }
 
 impl DownlinkSpawner<TestAgent> for TestSpawner {

--- a/server/swimos_agent/src/tests.rs
+++ b/server/swimos_agent/src/tests.rs
@@ -88,6 +88,10 @@ impl<Context> Spawner<Context> for NoSpawn {
     fn spawn_suspend(&self, _: HandlerFuture<Context>) {
         panic!("No suspended futures expected.");
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer.");
+    }
 }
 
 impl AgentContext for DummyAgentContext {

--- a/server/swimos_connector/src/connector/tests.rs
+++ b/server/swimos_connector/src/connector/tests.rs
@@ -100,6 +100,10 @@ impl Spawner<ConnectorAgent> for TestSpawner {
     fn spawn_suspend(&self, fut: HandlerFuture<ConnectorAgent>) {
         self.futures.push(fut);
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer.");
+    }
 }
 
 impl DownlinkSpawner<ConnectorAgent> for TestSpawner {

--- a/server/swimos_connector/src/generic/tests.rs
+++ b/server/swimos_connector/src/generic/tests.rs
@@ -387,6 +387,10 @@ impl Spawner<ConnectorAgent> for NoSpawn {
     fn spawn_suspend(&self, _fut: HandlerFuture<ConnectorAgent>) {
         panic!("Spawning futures not supported.");
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer.");
+    }
 }
 
 impl DownlinkSpawner<ConnectorAgent> for NoSpawn {

--- a/server/swimos_connector/src/lifecycle/mod.rs
+++ b/server/swimos_connector/src/lifecycle/mod.rs
@@ -17,7 +17,8 @@ mod tests;
 
 use swimos_agent::{
     agent_lifecycle::{
-        item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop, HandlerContext,
+        item_event::ItemEvent, on_init::OnInit, on_start::OnStart, on_stop::OnStop,
+        on_timer::OnTimer, HandlerContext,
     },
     event_handler::{
         ActionContext, EventHandler, HandlerActionExt, TryHandlerActionExt, UnitHandler,
@@ -81,6 +82,15 @@ where
 {
     fn on_stop(&self) -> impl EventHandler<ConnectorAgent> + '_ {
         self.0.on_stop()
+    }
+}
+
+impl<C> OnTimer<ConnectorAgent> for ConnectorLifecycle<C>
+where
+    C: Connector + Send,
+{
+    fn on_timer(&self, _timer_id: u64) -> impl EventHandler<ConnectorAgent> + '_ {
+        UnitHandler::default()
     }
 }
 

--- a/server/swimos_connector/src/lifecycle/tests.rs
+++ b/server/swimos_connector/src/lifecycle/tests.rs
@@ -49,6 +49,10 @@ impl Spawner<ConnectorAgent> for TestSpawner {
     fn spawn_suspend(&self, fut: HandlerFuture<ConnectorAgent>) {
         self.futures.push(fut);
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer.");
+    }
 }
 
 impl DownlinkSpawner<ConnectorAgent> for TestSpawner {

--- a/server/swimos_connector_kafka/src/connector/tests/mod.rs
+++ b/server/swimos_connector_kafka/src/connector/tests/mod.rs
@@ -80,6 +80,10 @@ impl Spawner<ConnectorAgent> for TestSpawner {
     fn spawn_suspend(&self, fut: HandlerFuture<ConnectorAgent>) {
         self.suspended.push(fut);
     }
+
+    fn schedule_timer(&self, _at: tokio::time::Instant, _id: u64) {
+        panic!("Unexpected timer");
+    }
 }
 
 impl DownlinkSpawner<ConnectorAgent> for TestSpawner {


### PR DESCRIPTION
This allows scheduling timeouts that can access the lifecycle.

Intiially, this is to help with implementing connectors but will eventually be exposed in the agent lifecycle macro.