### PR TITLE
Abstracts `MapStore` and `MapLane` over the underlying map implementation.

### DIFF
--- a/server/swimos_agent/src/agent_lifecycle/item_event/map/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/item_event/map/mod.rs
@@ -32,7 +32,7 @@ use crate::lanes::map::{
     },
     MapLaneEvent,
 };
-use crate::map_storage::MapOps;
+use crate::map_storage::MapOpsWithEntry;
 
 use super::{HLeaf, HTree, ItemEvent, ItemEventShared};
 
@@ -75,11 +75,11 @@ fn map_handler<'a, Context, K, V, M, LC>(
 where
     K: Hash + Eq,
     LC: MapLaneLifecycle<K, V, M, Context>,
-    M: MapOps<K, V>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     match event {
         MapLaneEvent::Update(k, old) => {
-            let new = map.get(&k).expect("Entry missing.");
+            let new = &map[&k];
             Coproduct::Inl(lifecycle.on_update(map, k, old, new))
         }
         MapLaneEvent::Remove(k, v) => {
@@ -101,11 +101,11 @@ fn map_handler_shared<'a, Context, Shared, K, V, M, LC>(
 where
     K: Hash + Eq,
     LC: MapLaneLifecycleShared<K, V, M, Context, Shared>,
-    M: MapOps<K, V>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     match event {
         MapLaneEvent::Update(k, old) => {
-            let new = map.get(&k).expect("Entry missing.");
+            let new = &map[&k];
             Coproduct::Inl(lifecycle.on_update(shared, handler_context, map, k, old, new))
         }
         MapLaneEvent::Remove(k, v) => Coproduct::Inr(Coproduct::Inl(lifecycle.on_remove(
@@ -215,7 +215,7 @@ where
     LC: MapLaneLifecycle<K, V, M, Context>,
     L: HTree + ItemEvent<Context>,
     R: HTree + ItemEvent<Context>,
-    M: MapOps<K, V>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type ItemEventHandler<'a> = MapBranchHandler<'a, Context, K, V, M, LC, L, R>
     where
@@ -257,7 +257,7 @@ where
     LC: MapLaneLifecycleShared<K, V, M, Context, Shared>,
     L: HTree + ItemEventShared<Context, Shared>,
     R: HTree + ItemEventShared<Context, Shared>,
-    M: MapOps<K, V>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type ItemEventHandler<'a> = MapBranchHandlerShared<'a, Context, Shared, K, V, M, LC, L, R>
     where

--- a/server/swimos_agent/src/agent_lifecycle/item_event/map/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/item_event/map/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::{cmp::Ordering, collections::HashMap};
 
 use frunk::{Coprod, Coproduct};
 use futures::future::Either;
@@ -30,62 +30,56 @@ use crate::lanes::map::{
         on_update::{OnUpdate, OnUpdateShared},
         MapLaneLifecycle,
     },
-    MapLane, MapLaneEvent,
+    MapLaneEvent,
 };
-use crate::stores::MapStore;
+use crate::map_storage::MapOps;
 
 use super::{HLeaf, HTree, ItemEvent, ItemEventShared};
 
 #[cfg(test)]
 mod tests;
 
-pub type MapLeaf<Context, K, V, LC> = MapBranch<Context, K, V, LC, HLeaf, HLeaf>;
-pub type MapBranch<Context, K, V, LC, L, R> = MapLikeBranch<Context, K, V, MapLane<K, V>, LC, L, R>;
-
-pub type MapStoreLeaf<Context, K, V, LC> = MapStoreBranch<Context, K, V, LC, HLeaf, HLeaf>;
-pub type MapStoreBranch<Context, K, V, LC, L, R> =
-    MapLikeBranch<Context, K, V, MapStore<K, V>, LC, L, R>;
-
-pub type MapLifecycleHandler<'a, Context, K, V, LC> = Coprod!(
-    <LC as OnUpdate<K, V, Context>>::OnUpdateHandler<'a>,
-    <LC as OnRemove<K, V, Context>>::OnRemoveHandler<'a>,
-    <LC as OnClear<K, V, Context>>::OnClearHandler<'a>,
+pub type MapLifecycleHandler<'a, Context, K, V, M, LC> = Coprod!(
+    <LC as OnUpdate<K, V, M, Context>>::OnUpdateHandler<'a>,
+    <LC as OnRemove<K, V, M, Context>>::OnRemoveHandler<'a>,
+    <LC as OnClear<M, Context>>::OnClearHandler<'a>,
 );
 
-pub type MapLifecycleHandlerShared<'a, Context, Shared, K, V, LC> = Coprod!(
-    <LC as OnUpdateShared<K, V, Context, Shared>>::OnUpdateHandler<'a>,
-    <LC as OnRemoveShared<K, V, Context, Shared>>::OnRemoveHandler<'a>,
-    <LC as OnClearShared<K, V, Context, Shared>>::OnClearHandler<'a>,
+pub type MapLifecycleHandlerShared<'a, Context, Shared, K, V, M, LC> = Coprod!(
+    <LC as OnUpdateShared<K, V, M, Context, Shared>>::OnUpdateHandler<'a>,
+    <LC as OnRemoveShared<K, V, M, Context, Shared>>::OnRemoveHandler<'a>,
+    <LC as OnClearShared<M, Context, Shared>>::OnClearHandler<'a>,
 );
 
-type MapBranchHandler<'a, Context, K, V, LC, L, R> = Either<
+type MapBranchHandler<'a, Context, K, V, M, LC, L, R> = Either<
     <L as ItemEvent<Context>>::ItemEventHandler<'a>,
     Either<
-        MapLifecycleHandler<'a, Context, K, V, LC>,
+        MapLifecycleHandler<'a, Context, K, V, M, LC>,
         <R as ItemEvent<Context>>::ItemEventHandler<'a>,
     >,
 >;
 
-type MapBranchHandlerShared<'a, Context, Shared, K, V, LC, L, R> = Either<
+type MapBranchHandlerShared<'a, Context, Shared, K, V, M, LC, L, R> = Either<
     <L as ItemEventShared<Context, Shared>>::ItemEventHandler<'a>,
     Either<
-        MapLifecycleHandlerShared<'a, Context, Shared, K, V, LC>,
+        MapLifecycleHandlerShared<'a, Context, Shared, K, V, M, LC>,
         <R as ItemEventShared<Context, Shared>>::ItemEventHandler<'a>,
     >,
 >;
 
-fn map_handler<'a, Context, K, V, LC>(
-    event: MapLaneEvent<K, V>,
+fn map_handler<'a, Context, K, V, M, LC>(
+    event: MapLaneEvent<K, V, M>,
     lifecycle: &'a LC,
-    map: &HashMap<K, V>,
-) -> MapLifecycleHandler<'a, Context, K, V, LC>
+    map: &M,
+) -> MapLifecycleHandler<'a, Context, K, V, M, LC>
 where
     K: Hash + Eq,
-    LC: MapLaneLifecycle<K, V, Context>,
+    LC: MapLaneLifecycle<K, V, M, Context>,
+    M: MapOps<K, V>,
 {
     match event {
         MapLaneEvent::Update(k, old) => {
-            let new = &map[&k];
+            let new = map.get(&k).expect("Entry missing.");
             Coproduct::Inl(lifecycle.on_update(map, k, old, new))
         }
         MapLaneEvent::Remove(k, v) => {
@@ -97,20 +91,21 @@ where
     }
 }
 
-fn map_handler_shared<'a, Context, Shared, K, V, LC>(
+fn map_handler_shared<'a, Context, Shared, K, V, M, LC>(
     shared: &'a Shared,
     handler_context: HandlerContext<Context>,
-    event: MapLaneEvent<K, V>,
+    event: MapLaneEvent<K, V, M>,
     lifecycle: &'a LC,
-    map: &HashMap<K, V>,
-) -> MapLifecycleHandlerShared<'a, Context, Shared, K, V, LC>
+    map: &M,
+) -> MapLifecycleHandlerShared<'a, Context, Shared, K, V, M, LC>
 where
     K: Hash + Eq,
-    LC: MapLaneLifecycleShared<K, V, Context, Shared>,
+    LC: MapLaneLifecycleShared<K, V, M, Context, Shared>,
+    M: MapOps<K, V>,
 {
     match event {
         MapLaneEvent::Update(k, old) => {
-            let new = &map[&k];
+            let new = map.get(&k).expect("Entry missing.");
             Coproduct::Inl(lifecycle.on_update(shared, handler_context, map, k, old, new))
         }
         MapLaneEvent::Remove(k, v) => Coproduct::Inr(Coproduct::Inl(lifecycle.on_remove(
@@ -126,10 +121,10 @@ where
     }
 }
 
-type KeyValue<K, V> = fn((K, V)) -> (K, V);
+type MapKeyValue<M, K, V> = fn((&M, K, V)) -> (K, V);
 /// Map lane lifecycle as a branch node of an [`HTree`].
-pub struct MapLikeBranch<Context, K, V, Item, LC, L, R> {
-    _type: PhantomData<KeyValue<K, V>>,
+pub struct MapLikeBranch<Context, K, V, M, Item, LC, L, R> {
+    _type: PhantomData<MapKeyValue<M, K, V>>,
     label: &'static str,
     projection: fn(&Context) -> &Item,
     lifecycle: LC,
@@ -137,8 +132,8 @@ pub struct MapLikeBranch<Context, K, V, Item, LC, L, R> {
     right: R,
 }
 
-impl<Context, K, V, Item, LC: Clone, L: Clone, R: Clone> Clone
-    for MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, K, V, M, Item, LC: Clone, L: Clone, R: Clone> Clone
+    for MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 {
     fn clone(&self) -> Self {
         Self {
@@ -152,15 +147,15 @@ impl<Context, K, V, Item, LC: Clone, L: Clone, R: Clone> Clone
     }
 }
 
-impl<Context, K, V, Item, LC, L: HTree, R: HTree> HTree
-    for MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, K, V, M, Item, LC, L: HTree, R: HTree> HTree
+    for MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 {
     fn label(&self) -> Option<&'static str> {
         Some(self.label)
     }
 }
 
-impl<Context, K, V, Item, LC, L, R> Debug for MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, K, V, M, Item, LC, L, R> Debug for MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 where
     LC: Debug,
     L: Debug,
@@ -177,13 +172,13 @@ where
     }
 }
 
-impl<Context, K, V, Item, LC> MapLikeBranch<Context, K, V, Item, LC, HLeaf, HLeaf> {
+impl<Context, K, V, M, Item, LC> MapLikeBranch<Context, K, V, M, Item, LC, HLeaf, HLeaf> {
     pub fn leaf(label: &'static str, projection: fn(&Context) -> &Item, lifecycle: LC) -> Self {
         MapLikeBranch::new(label, projection, lifecycle, HLeaf, HLeaf)
     }
 }
 
-impl<Context, K, V, Item, LC, L, R> MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, K, V, M, Item, LC, L, R> MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 where
     L: HTree,
     R: HTree,
@@ -212,16 +207,17 @@ where
     }
 }
 
-impl<Context, K, V, Item, LC, L, R> ItemEvent<Context>
-    for MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, K, V, M, Item, LC, L, R> ItemEvent<Context>
+    for MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 where
     K: Clone + Eq + Hash,
-    Item: MapItem<K, V>,
-    LC: MapLaneLifecycle<K, V, Context>,
+    Item: MapItem<K, V, M>,
+    LC: MapLaneLifecycle<K, V, M, Context>,
     L: HTree + ItemEvent<Context>,
     R: HTree + ItemEvent<Context>,
+    M: MapOps<K, V>,
 {
-    type ItemEventHandler<'a> = MapBranchHandler<'a, Context, K, V, LC, L, R>
+    type ItemEventHandler<'a> = MapBranchHandler<'a, Context, K, V, M, LC, L, R>
     where
         Self: 'a;
 
@@ -253,16 +249,17 @@ where
     }
 }
 
-impl<Context, Shared, K, V, Item, LC, L, R> ItemEventShared<Context, Shared>
-    for MapLikeBranch<Context, K, V, Item, LC, L, R>
+impl<Context, Shared, K, V, M, Item, LC, L, R> ItemEventShared<Context, Shared>
+    for MapLikeBranch<Context, K, V, M, Item, LC, L, R>
 where
     K: Clone + Eq + Hash,
-    Item: MapItem<K, V>,
-    LC: MapLaneLifecycleShared<K, V, Context, Shared>,
+    Item: MapItem<K, V, M>,
+    LC: MapLaneLifecycleShared<K, V, M, Context, Shared>,
     L: HTree + ItemEventShared<Context, Shared>,
     R: HTree + ItemEventShared<Context, Shared>,
+    M: MapOps<K, V>,
 {
-    type ItemEventHandler<'a> = MapBranchHandlerShared<'a, Context, Shared, K, V, LC, L, R>
+    type ItemEventHandler<'a> = MapBranchHandlerShared<'a, Context, Shared, K, V, M, LC, L, R>
     where
         Self: 'a,
         Shared: 'a;

--- a/server/swimos_agent/src/agent_lifecycle/item_event/map/tests.rs
+++ b/server/swimos_agent/src/agent_lifecycle/item_event/map/tests.rs
@@ -20,7 +20,7 @@ use swimos_model::Text;
 use swimos_utilities::routing::RouteUri;
 
 use crate::{
-    agent_lifecycle::item_event::{tests::run_handler, HLeaf, ItemEvent, MapBranch, MapLeaf},
+    agent_lifecycle::item_event::{tests::run_handler, HLeaf, ItemEvent},
     event_handler::{ActionContext, HandlerAction, StepResult},
     lanes::map::{
         lifecycle::{on_clear::OnClear, on_remove::OnRemove, on_update::OnUpdate},
@@ -28,6 +28,12 @@ use crate::{
     },
     meta::AgentMetadata,
 };
+
+use super::MapLikeBranch;
+
+type MapLeaf<Context, K, V, M, LC> = MapBranch<Context, K, V, M, LC, HLeaf, HLeaf>;
+type MapBranch<Context, K, V, M, LC, L, R> =
+    MapLikeBranch<Context, K, V, M, MapLane<K, V, M>, LC, L, R>;
 
 struct TestAgent {
     first: MapLane<i32, i32>,
@@ -248,7 +254,7 @@ impl<K, V> FakeLifecycle<K, V> {
     }
 }
 
-impl<K, V> OnUpdate<K, V, TestAgent> for FakeLifecycle<K, V>
+impl<K, V> OnUpdate<K, V, HashMap<K, V>, TestAgent> for FakeLifecycle<K, V>
 where
     K: Clone + Send + 'static,
     V: Clone + Send + 'static,
@@ -268,7 +274,7 @@ where
     }
 }
 
-impl<K, V> OnRemove<K, V, TestAgent> for FakeLifecycle<K, V>
+impl<K, V> OnRemove<K, V, HashMap<K, V>, TestAgent> for FakeLifecycle<K, V>
 where
     K: Clone + Send + 'static,
     V: Clone + Send + 'static,
@@ -287,7 +293,7 @@ where
     }
 }
 
-impl<K, V> OnClear<K, V, TestAgent> for FakeLifecycle<K, V>
+impl<K, V> OnClear<HashMap<K, V>, TestAgent> for FakeLifecycle<K, V>
 where
     K: Clone + Send + 'static,
     V: Clone + Send + 'static,

--- a/server/swimos_agent/src/agent_lifecycle/item_event/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/item_event/mod.rs
@@ -42,10 +42,7 @@ pub use demand_map::{
     DemandMapBranch, DemandMapLeaf, DemandMapLifecycleHandler, DemandMapLifecycleHandlerShared,
 };
 pub use http::{HttpBranch, HttpLeaf};
-pub use map::{
-    MapBranch, MapLeaf, MapLifecycleHandler, MapLifecycleHandlerShared, MapLikeBranch,
-    MapStoreBranch, MapStoreLeaf,
-};
+pub use map::{MapLifecycleHandler, MapLifecycleHandlerShared, MapLikeBranch};
 pub use value::{
     ValueBranch, ValueLeaf, ValueLifecycleHandler, ValueLifecycleHandlerShared, ValueLikeBranch,
     ValueStoreBranch, ValueStoreLeaf,

--- a/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
@@ -326,12 +326,12 @@ impl<Agent: AgentDescription + 'static> HandlerContext<Agent> {
     ///
     /// #Arguments
     /// * `item` - Projection to the map-like item.
-    pub fn get_map<Item, K, V>(
+    pub fn get_map<Item, K, V, M>(
         &self,
         item: fn(&Agent) -> &Item,
-    ) -> impl HandlerAction<Agent, Completion = HashMap<K, V>> + Send + 'static
+    ) -> impl HandlerAction<Agent, Completion = M> + Send + 'static
     where
-        Item: MapLikeItem<K, V>,
+        Item: MapLikeItem<K, V, M>,
         K: Send + Clone + Eq + Hash + 'static,
         V: Send + Clone + 'static,
     {

--- a/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
+++ b/server/swimos_agent/src/agent_lifecycle/utility/mod.rs
@@ -234,13 +234,13 @@ impl<Agent: AgentDescription + 'static> HandlerContext<Agent> {
     ) -> impl HandlerAction<Agent, Completion = U> + Send + 'a
     where
         Agent: 'static,
-        Item: InspectableMapLikeItem<K, V> + 'static,
+        Item: InspectableMapLikeItem<K, V, B> + 'static,
         K: Send + Clone + Eq + Hash + 'static,
         V: Borrow<B> + 'static,
         B: ?Sized + 'static,
         F: FnOnce(Option<&B>) -> U + Send + 'a,
     {
-        Item::with_entry_handler::<Agent, F, B, U>(item, key, f)
+        Item::with_entry_handler::<Agent, F, U>(item, key, f)
     }
 
     /// Create an event handler that will transform the value in an entry of a map lane or store of the agent.

--- a/server/swimos_agent/src/downlink_lifecycle/map/on_remove.rs
+++ b/server/swimos_agent/src/downlink_lifecycle/map/on_remove.rs
@@ -119,9 +119,9 @@ where
 
 impl<K, V, Context, Shared, F> OnDownlinkRemoveShared<K, V, Context, Shared> for FnHandler<F>
 where
-    F: for<'a> MapRemoveFn<'a, Context, Shared, K, V> + Send,
+    F: for<'a> MapRemoveFn<'a, Context, Shared, K, V, HashMap<K, V>> + Send,
 {
-    type OnRemoveHandler<'a> = <F as MapRemoveFn<'a, Context, Shared, K, V>>::Handler
+    type OnRemoveHandler<'a> = <F as MapRemoveFn<'a, Context, Shared, K, V, HashMap<K, V>>>::Handler
     where
         Self: 'a,
         Shared: 'a;

--- a/server/swimos_agent/src/downlink_lifecycle/map/on_update.rs
+++ b/server/swimos_agent/src/downlink_lifecycle/map/on_update.rs
@@ -192,9 +192,9 @@ where
 
 impl<K, V, Context, Shared, F> OnDownlinkUpdateShared<K, V, Context, Shared> for FnHandler<F>
 where
-    F: for<'a> MapUpdateFn<'a, Context, Shared, K, V> + Send,
+    F: for<'a> MapUpdateFn<'a, Context, Shared, K, V, HashMap<K, V>> + Send,
 {
-    type OnUpdateHandler<'a> = <F as MapUpdateFn<'a, Context, Shared, K, V>>::Handler
+    type OnUpdateHandler<'a> = <F as MapUpdateFn<'a, Context, Shared, K, V, HashMap<K, V>>>::Handler
     where
         Self: 'a,
         Shared: 'a;
@@ -218,9 +218,9 @@ impl<B, K, V, Context, Shared, F> OnDownlinkUpdateShared<K, V, Context, Shared>
 where
     B: ?Sized,
     V: Borrow<B>,
-    F: for<'a> MapUpdateBorrowFn<'a, Context, Shared, K, V, B> + Send,
+    F: for<'a> MapUpdateBorrowFn<'a, Context, Shared, K, V, HashMap<K, V>, B> + Send,
 {
-    type OnUpdateHandler<'a> = <F as MapUpdateBorrowFn<'a, Context, Shared, K, V, B>>::Handler
+    type OnUpdateHandler<'a> = <F as MapUpdateBorrowFn<'a, Context, Shared, K, V, HashMap<K, V>, B>>::Handler
     where
         Self: 'a,
         Shared: 'a;

--- a/server/swimos_agent/src/event_handler/handler_fn.rs
+++ b/server/swimos_agent/src/event_handler/handler_fn.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use crate::{
     agent_lifecycle::HandlerContext,
     lanes::http::{lifecycle::HttpRequestContext, Response, UnitResponse},
@@ -199,23 +197,23 @@ where
     }
 }
 
-pub trait MapRemoveFn<'a, Context, Shared, K, V> {
+pub trait MapRemoveFn<'a, Context, Shared, K, V, M> {
     type Handler: EventHandler<Context> + 'a;
 
     fn make_handler(
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: V,
     ) -> Self::Handler;
 }
 
-impl<'a, Context, Shared, K, V, F, H> MapRemoveFn<'a, Context, Shared, K, V> for F
+impl<'a, Context, Shared, K, V, M, F, H> MapRemoveFn<'a, Context, Shared, K, V, M> for F
 where
     H: EventHandler<Context> + 'a,
-    F: Fn(&'a Shared, HandlerContext<Context>, &HashMap<K, V>, K, V) -> H + 'a,
+    F: Fn(&'a Shared, HandlerContext<Context>, &M, K, V) -> H + 'a,
     Shared: 'a,
 {
     type Handler = H;
@@ -224,7 +222,7 @@ where
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: V,
     ) -> Self::Handler {
@@ -232,24 +230,24 @@ where
     }
 }
 
-pub trait MapUpdateFn<'a, Context, Shared, K, V> {
+pub trait MapUpdateFn<'a, Context, Shared, K, V, M> {
     type Handler: EventHandler<Context> + 'a;
 
     fn make_handler(
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: Option<V>,
         new_value: &V,
     ) -> Self::Handler;
 }
 
-impl<'a, Context, Shared, K, V, F, H> MapUpdateFn<'a, Context, Shared, K, V> for F
+impl<'a, Context, Shared, K, V, M, F, H> MapUpdateFn<'a, Context, Shared, K, V, M> for F
 where
     H: EventHandler<Context> + 'a,
-    F: Fn(&'a Shared, HandlerContext<Context>, &HashMap<K, V>, K, Option<V>, &V) -> H + 'a,
+    F: Fn(&'a Shared, HandlerContext<Context>, &M, K, Option<V>, &V) -> H + 'a,
     Shared: 'a,
 {
     type Handler = H;
@@ -258,7 +256,7 @@ where
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: Option<V>,
         new_value: &V,
@@ -267,25 +265,25 @@ where
     }
 }
 
-pub trait MapUpdateBorrowFn<'a, Context, Shared, K, V, B: ?Sized> {
+pub trait MapUpdateBorrowFn<'a, Context, Shared, K, V, M, B: ?Sized> {
     type Handler: EventHandler<Context> + 'a;
 
     fn make_handler(
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: Option<V>,
         new_value: &B,
     ) -> Self::Handler;
 }
 
-impl<'a, Context, Shared, K, V, B, F, H> MapUpdateBorrowFn<'a, Context, Shared, K, V, B> for F
+impl<'a, Context, Shared, K, V, M, B, F, H> MapUpdateBorrowFn<'a, Context, Shared, K, V, M, B> for F
 where
     B: ?Sized,
     H: EventHandler<Context> + 'a,
-    F: Fn(&'a Shared, HandlerContext<Context>, &HashMap<K, V>, K, Option<V>, &B) -> H + 'a,
+    F: Fn(&'a Shared, HandlerContext<Context>, &M, K, Option<V>, &B) -> H + 'a,
     Shared: 'a,
 {
     type Handler = H;
@@ -294,7 +292,7 @@ where
         &'a self,
         shared: &'a Shared,
         handler_context: HandlerContext<Context>,
-        map: &HashMap<K, V>,
+        map: &M,
         key: K,
         prev_value: Option<V>,
         new_value: &B,

--- a/server/swimos_agent/src/item.rs
+++ b/server/swimos_agent/src/item.rs
@@ -35,19 +35,19 @@ pub trait ValueItem<T>: AgentItem {
     fn init(&self, value: T);
 }
 
-pub trait MapItem<K, V>: AgentItem {
-    fn init(&self, map: HashMap<K, V>);
+pub trait MapItem<K, V, M = HashMap<K, V>>: AgentItem {
+    fn init(&self, map: M);
 
     fn read_with_prev<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(Option<MapLaneEvent<K, V>>, &HashMap<K, V>) -> R;
+        F: FnOnce(Option<MapLaneEvent<K, V, M>>, &M) -> R;
 }
 
-pub trait MapLikeItem<K, V> {
+pub trait MapLikeItem<K, V, M = HashMap<K, V>> {
     type GetHandler<C>: HandlerAction<C, Completion = Option<V>> + Send + 'static
     where
         C: AgentDescription + 'static;
-    type GetMapHandler<C>: HandlerAction<C, Completion = HashMap<K, V>> + Send + 'static
+    type GetMapHandler<C>: HandlerAction<C, Completion = M> + Send + 'static
     where
         C: AgentDescription + 'static;
 
@@ -61,25 +61,21 @@ pub trait MapLikeItem<K, V> {
     ) -> Self::GetMapHandler<C>;
 }
 
-pub trait InspectableMapLikeItem<K, V> {
-    type WithEntryHandler<'a, C, F, B, U>: HandlerAction<C, Completion = U> + Send + 'a
+pub trait InspectableMapLikeItem<K, V: Borrow<B>, B: ?Sized + 'static> {
+    type WithEntryHandler<'a, C, F, U>: HandlerAction<C, Completion = U> + Send + 'a
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 
-    fn with_entry_handler<'a, C, F, B, U>(
+    fn with_entry_handler<'a, C, F, U>(
         projection: fn(&C) -> &Self,
         key: K,
         f: F,
-    ) -> Self::WithEntryHandler<'a, C, F, B, U>
+    ) -> Self::WithEntryHandler<'a, C, F, U>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 }
 

--- a/server/swimos_agent/src/lanes/join/map/mod.rs
+++ b/server/swimos_agent/src/lanes/join/map/mod.rs
@@ -882,30 +882,27 @@ where
     }
 }
 
-impl<L, K, V> InspectableMapLikeItem<K, V> for JoinMapLane<L, K, V>
+impl<L, K, V, B> InspectableMapLikeItem<K, V, B> for JoinMapLane<L, K, V>
 where
     L: Send + 'static,
     K: Clone + Eq + Hash + Send + 'static,
-    V: Send + 'static,
+    V: Borrow<B> + Send + 'static,
+    B: ?Sized + 'static,
 {
-    type WithEntryHandler<'a, C, F, B, U> = JoinMapLaneWithEntry<C, L, K, V, F, B>
+    type WithEntryHandler<'a, C, F, U> = JoinMapLaneWithEntry<C, L, K, V, F, B>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 
-    fn with_entry_handler<'a, C, F, B, U>(
+    fn with_entry_handler<'a, C, F, U>(
         projection: fn(&C) -> &Self,
         key: K,
         f: F,
-    ) -> Self::WithEntryHandler<'a, C, F, B, U>
+    ) -> Self::WithEntryHandler<'a, C, F, U>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a,
     {
         JoinMapLaneWithEntry::new(projection, key, f)

--- a/server/swimos_agent/src/lanes/join/value/mod.rs
+++ b/server/swimos_agent/src/lanes/join/value/mod.rs
@@ -656,29 +656,26 @@ where
     }
 }
 
-impl<K, V> InspectableMapLikeItem<K, V> for JoinValueLane<K, V>
+impl<K, V, B> InspectableMapLikeItem<K, V, B> for JoinValueLane<K, V>
 where
     K: Clone + Eq + Hash + Send + 'static,
-    V: Send + 'static,
+    V: Borrow<B> + Send + 'static,
+    B: ?Sized + 'static,
 {
-    type WithEntryHandler<'a, C, F, B, U> = JoinValueLaneWithEntry<C, K, V, F, B>
+    type WithEntryHandler<'a, C, F, U> = JoinValueLaneWithEntry<C, K, V, F, B>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 
-    fn with_entry_handler<'a, C, F, B, U>(
+    fn with_entry_handler<'a, C, F, U>(
         projection: fn(&C) -> &Self,
         key: K,
         f: F,
-    ) -> Self::WithEntryHandler<'a, C, F, B, U>
+    ) -> Self::WithEntryHandler<'a, C, F, U>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a,
     {
         JoinValueLaneWithEntry::new(projection, key, f)

--- a/server/swimos_agent/src/lanes/map/event.rs
+++ b/server/swimos_agent/src/lanes/map/event.rs
@@ -17,16 +17,17 @@ use std::hash::Hash;
 
 /// Enumeration of the possible inputs to a map lane event handler.
 #[derive(Debug, Clone)]
-pub enum MapLaneEvent<K, V> {
-    Clear(HashMap<K, V>),
+pub enum MapLaneEvent<K, V, M = HashMap<K, V>> {
+    Clear(M),
     Update(K, Option<V>),
     Remove(K, V),
 }
 
-impl<K, V> PartialEq for MapLaneEvent<K, V>
+impl<K, V, M> PartialEq for MapLaneEvent<K, V, M>
 where
     K: Eq + Hash,
     V: PartialEq,
+    M: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -38,10 +39,11 @@ where
     }
 }
 
-impl<K, V> Eq for MapLaneEvent<K, V>
+impl<K, V, M> Eq for MapLaneEvent<K, V, M>
 where
     K: Eq + Hash,
     V: Eq,
+    M: Eq,
 {
     fn assert_receiver_is_total_eq(&self) {}
 }

--- a/server/swimos_agent/src/lanes/map/mod.rs
+++ b/server/swimos_agent/src/lanes/map/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         HandlerTrans, Modification, StepResult,
     },
     item::{AgentItem, InspectableMapLikeItem, MapItem, MapLikeItem, MutableMapLikeItem},
-    map_storage::{MapStoreInner, TransformEntryResult},
+    map_storage::{MapOps, MapOpsWithEntry, MapStoreInner, TransformEntryResult},
     meta::AgentMetadata,
 };
 
@@ -53,26 +53,23 @@ pub use event::MapLaneEvent;
 
 use super::{LaneItem, ProjTransform};
 
-type Inner<K, V> = MapStoreInner<K, V, WriteQueues<K>>;
+type Inner<K, V, M> = MapStoreInner<K, V, WriteQueues<K>, M>;
 
 /// Model of a value lane. This maintains a sate consisting of a hash-map from keys to values. It generates an
 /// event whenever the map is updated (updating the value for a key, removing a key or clearing the map).
-///
-/// TODO: This could be parameterized over the type of the hash (and potentially over the kind of the map,
-/// potentially allowing a choice between hash and ordered maps).
 #[derive(Debug)]
-pub struct MapLane<K, V> {
+pub struct MapLane<K, V, M = HashMap<K, V>> {
     id: u64,
-    inner: RefCell<Inner<K, V>>,
+    inner: RefCell<Inner<K, V, M>>,
 }
 
 assert_impl_all!(MapLane<(), ()>: Send);
 
-impl<K, V> MapLane<K, V> {
+impl<K, V, M> MapLane<K, V, M> {
     /// # Arguments
     /// * `id` - The ID of the lane. This should be unique within an agent.
     /// * `init` - The initial contents of the map.
-    pub fn new(id: u64, init: HashMap<K, V>) -> Self {
+    pub fn new(id: u64, init: M) -> Self {
         MapLane {
             id,
             inner: RefCell::new(Inner::new(init)),
@@ -80,31 +77,33 @@ impl<K, V> MapLane<K, V> {
     }
 }
 
-impl<K, V> AgentItem for MapLane<K, V> {
+impl<K, V, M> AgentItem for MapLane<K, V, M> {
     fn id(&self) -> u64 {
         self.id
     }
 }
 
-impl<K, V> MapItem<K, V> for MapLane<K, V>
+impl<K, V, M> MapItem<K, V, M> for MapLane<K, V, M>
 where
     K: Eq + Hash + Clone,
+    M: MapOps<K, V>,
 {
-    fn init(&self, map: HashMap<K, V>) {
+    fn init(&self, map: M) {
         self.inner.borrow_mut().init(map)
     }
 
     fn read_with_prev<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(Option<MapLaneEvent<K, V>>, &HashMap<K, V>) -> R,
+        F: FnOnce(Option<MapLaneEvent<K, V, M>>, &M) -> R,
     {
         self.inner.borrow_mut().read_with_prev(f)
     }
 }
 
-impl<K, V> MapLane<K, V>
+impl<K, V, M> MapLane<K, V, M>
 where
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     /// Update the value associated with a key.
     pub(crate) fn update(&self, key: K, value: V) {
@@ -135,6 +134,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
         F: FnOnce(Option<&V>) -> R,
+        M: MapOpsWithEntry<K, V, Q, V>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -142,7 +142,7 @@ where
     /// Read the complete state of the map.
     pub fn get_map<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&HashMap<K, V>) -> R,
+        F: FnOnce(&M) -> R,
     {
         self.inner.borrow().get_map(f)
     }
@@ -154,15 +154,13 @@ where
     }
 }
 
-impl<K, V> MapLane<K, V>
-where
-    K: Eq + Hash,
-{
+impl<K, V, M> MapLane<K, V, M> {
     pub fn with_entry<F, B, U>(&self, key: &K, f: F) -> U
     where
         B: ?Sized,
         V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U,
+        M: MapOpsWithEntry<K, V, K, B>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -170,10 +168,11 @@ where
 
 const INFALLIBLE_SER: &str = "Serializing lane responses to recon should be infallible.";
 
-impl<K, V> LaneItem for MapLane<K, V>
+impl<K, V, M> LaneItem for MapLane<K, V, M>
 where
     K: Clone + Eq + Hash + StructuralWritable,
     V: StructuralWritable,
+    M: MapOps<K, V>,
 {
     fn write_to_buffer(&self, buffer: &mut BytesMut) -> WriteResult {
         let mut encoder = MapLaneResponseEncoder::default();
@@ -192,13 +191,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will update the value of an entry in the map.
-pub struct MapLaneUpdate<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneUpdate<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     key_value: Option<(K, V)>,
 }
 
-impl<C, K, V> MapLaneUpdate<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, key: K, value: V) -> Self {
+impl<C, K, V, M> MapLaneUpdate<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, key: K, value: V) -> Self {
         MapLaneUpdate {
             projection,
             key_value: Some((key, value)),
@@ -206,10 +205,11 @@ impl<C, K, V> MapLaneUpdate<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneUpdate<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneUpdate<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -251,13 +251,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will remove an entry from the map.
-pub struct MapLaneRemove<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneRemove<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     key: Option<K>,
 }
 
-impl<C, K, V> MapLaneRemove<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, key: K) -> Self {
+impl<C, K, V, M> MapLaneRemove<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, key: K) -> Self {
         MapLaneRemove {
             projection,
             key: Some(key),
@@ -265,10 +265,11 @@ impl<C, K, V> MapLaneRemove<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneRemove<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneRemove<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -304,13 +305,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will clear the map.
-pub struct MapLaneClear<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneClear<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     done: bool,
 }
 
-impl<C, K, V> MapLaneClear<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>) -> Self {
+impl<C, K, V, M> MapLaneClear<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>) -> Self {
         MapLaneClear {
             projection,
             done: false,
@@ -318,10 +319,11 @@ impl<C, K, V> MapLaneClear<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneClear<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneClear<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -358,14 +360,14 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will get an entry from the map.
-pub struct MapLaneGet<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneGet<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     key: K,
     done: bool,
 }
 
-impl<C, K, V> MapLaneGet<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, key: K) -> Self {
+impl<C, K, V, M> MapLaneGet<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, key: K) -> Self {
         MapLaneGet {
             projection,
             key,
@@ -374,11 +376,12 @@ impl<C, K, V> MapLaneGet<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneGet<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneGet<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     V: Clone,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V>,
 {
     type Completion = Option<V>;
 
@@ -414,13 +417,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will read the entire state of a map lane.
-pub struct MapLaneGetMap<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneGetMap<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     done: bool,
 }
 
-impl<C, K, V> MapLaneGetMap<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>) -> Self {
+impl<C, K, V, M> MapLaneGetMap<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>) -> Self {
         MapLaneGetMap {
             projection,
             done: false,
@@ -428,13 +431,14 @@ impl<C, K, V> MapLaneGetMap<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneGetMap<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneGetMap<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     V: Clone,
+    M: MapOps<K, V> + Clone,
 {
-    type Completion = HashMap<K, V>;
+    type Completion = M;
 
     fn step(
         &mut self,
@@ -463,13 +467,35 @@ where
     }
 }
 
-impl<C, K, V, F, B, U> HandlerAction<C> for MapLaneWithEntry<C, K, V, F, B>
+///  An [event handler](crate::event_handler::EventHandler)`] that will alter an entry in the map.
+pub struct MapLaneWithEntry<C, K, V, F, B: ?Sized, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
+    key_and_f: Option<(K, F)>,
+    _type: PhantomData<fn(&B)>,
+}
+
+impl<C, K, V, F, B: ?Sized, M> MapLaneWithEntry<C, K, V, F, B, M> {
+    /// #Arguments
+    /// * `projection` - Projection from the agent context to the lane.
+    /// * `key` - Key of the entry.
+    /// * `f` - The closure to apply to the entry.
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, key: K, f: F) -> Self {
+        MapLaneWithEntry {
+            projection,
+            key_and_f: Some((key, f)),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<C, K, V, F, B, U, M> HandlerAction<C> for MapLaneWithEntry<C, K, V, F, B, M>
 where
     C: AgentDescription,
     K: Eq + Hash,
     B: ?Sized,
     V: Borrow<B>,
     F: FnOnce(Option<&B>) -> U,
+    M: MapOpsWithEntry<K, V, K, B>,
 {
     type Completion = U;
 
@@ -504,35 +530,14 @@ where
     }
 }
 
-///  An [event handler](crate::event_handler::EventHandler)`] that will alter an entry in the map.
-pub struct MapLaneWithEntry<C, K, V, F, B: ?Sized> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
-    key_and_f: Option<(K, F)>,
-    _type: PhantomData<fn(&B)>,
-}
-
-impl<C, K, V, F, B: ?Sized> MapLaneWithEntry<C, K, V, F, B> {
-    /// #Arguments
-    /// * `projection` - Projection from the agent context to the lane.
-    /// * `key` - Key of the entry.
-    /// * `f` - The closure to apply to the entry.
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, key: K, f: F) -> Self {
-        MapLaneWithEntry {
-            projection,
-            key_and_f: Some((key, f)),
-            _type: PhantomData,
-        }
-    }
-}
-
 ///  An [event handler](crate::event_handler::EventHandler)`] that will request a sync from the lane.
-pub struct MapLaneSync<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneSync<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     id: Option<Uuid>,
 }
 
-impl<C, K, V> MapLaneSync<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, id: Uuid) -> Self {
+impl<C, K, V, M> MapLaneSync<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, id: Uuid) -> Self {
         MapLaneSync {
             projection,
             id: Some(id),
@@ -540,10 +545,11 @@ impl<C, K, V> MapLaneSync<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneSync<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneSync<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -578,15 +584,15 @@ where
     }
 }
 
-type MapLaneHandler<C, K, V> = Coprod!(
-    MapLaneUpdate<C, K, V>,
-    MapLaneRemove<C, K, V>,
-    MapLaneClear<C, K, V>,
-    MapLaneDropOrTake<C, K, V>,
+type MapLaneHandler<C, K, V, M = HashMap<K, V>> = Coprod!(
+    MapLaneUpdate<C, K, V, M>,
+    MapLaneRemove<C, K, V, M>,
+    MapLaneClear<C, K, V, M>,
+    MapLaneDropOrTake<C, K, V, M>,
 );
 
-impl<C, K, V> HandlerTrans<MapMessage<K, V>> for ProjTransform<C, MapLane<K, V>> {
-    type Out = MapLaneHandler<C, K, V>;
+impl<C, K, V, M> HandlerTrans<MapMessage<K, V>> for ProjTransform<C, MapLane<K, V, M>> {
+    type Out = MapLaneHandler<C, K, V, M>;
 
     fn transform(self, input: MapMessage<K, V>) -> Self::Out {
         let ProjTransform { projection } = self;
@@ -697,31 +703,32 @@ where
     }
 }
 
-pub type DecodeAndApply<C, K, V> =
-    AndThen<DecodeMapMessage<K, V>, MapLaneHandler<C, K, V>, ProjTransform<C, MapLane<K, V>>>;
+pub type DecodeAndApply<C, K, V, M = HashMap<K, V>> =
+    AndThen<DecodeMapMessage<K, V>, MapLaneHandler<C, K, V, M>, ProjTransform<C, MapLane<K, V, M>>>;
 
 /// Create an event handler that will decode an incoming map message and apply the value into a map lane.
-pub fn decode_and_apply<C, K, V>(
+pub fn decode_and_apply<C, K, V, M>(
     message: MapMessage<BytesMut, BytesMut>,
-    projection: fn(&C) -> &MapLane<K, V>,
-) -> DecodeAndApply<C, K, V>
+    projection: fn(&C) -> &MapLane<K, V, M>,
+) -> DecodeAndApply<C, K, V, M>
 where
     C: AgentDescription,
     K: Form + Clone + Eq + Hash,
     V: RecognizerReadable,
+    M: MapOps<K, V>,
 {
     let decode: DecodeMapMessage<K, V> = DecodeMapMessage::new(message);
     decode.and_then(ProjTransform::new(projection))
 }
 
 /// An (event handler)[`crate::event_handler::EventHandler`] that will alter an entry in the map.
-pub struct MapLaneTransformEntry<C, K, V, F> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneTransformEntry<C, K, V, F, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     key_and_f: Option<(K, F)>,
 }
 
-impl<C, K, V, F> MapLaneTransformEntry<C, K, V, F> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, key: K, f: F) -> Self {
+impl<C, K, V, F, M> MapLaneTransformEntry<C, K, V, F, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, key: K, f: F) -> Self {
         MapLaneTransformEntry {
             projection,
             key_and_f: Some((key, f)),
@@ -729,11 +736,12 @@ impl<C, K, V, F> MapLaneTransformEntry<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneTransformEntry<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneTransformEntry<C, K, V, F, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     F: FnOnce(Option<&V>) -> Option<V>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -778,12 +786,13 @@ where
     }
 }
 
-impl<K, V> MapLikeItem<K, V> for MapLane<K, V>
+impl<K, V, M> MapLikeItem<K, V, M> for MapLane<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V> + Clone + 'static,
 {
-    type GetHandler<C> = MapLaneGet<C, K, V>
+    type GetHandler<C> = MapLaneGet<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -794,7 +803,7 @@ where
         MapLaneGet::new(projection, key)
     }
 
-    type GetMapHandler<C> = MapLaneGetMap<C, K, V>
+    type GetMapHandler<C> = MapLaneGetMap<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -805,13 +814,14 @@ where
     }
 }
 
-impl<K, V, B> InspectableMapLikeItem<K, V, B> for MapLane<K, V>
+impl<K, V, B, M> InspectableMapLikeItem<K, V, B> for MapLane<K, V, M>
 where
     K: Eq + Hash + Send + 'static,
     V: Borrow<B> + 'static,
     B: ?Sized + 'static,
+    M: MapOpsWithEntry<K, V, K, B>,
 {
-    type WithEntryHandler<'a, C, F, U> = MapLaneWithEntry<C, K, V, F, B>
+    type WithEntryHandler<'a, C, F, U> = MapLaneWithEntry<C, K, V, F, B, M>
     where
         Self: 'static,
         C: AgentDescription + 'a,
@@ -831,20 +841,21 @@ where
     }
 }
 
-impl<K, V> MutableMapLikeItem<K, V> for MapLane<K, V>
+impl<K, V, M> MutableMapLikeItem<K, V> for MapLane<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Send + 'static,
+    M: MapOps<K, V> + 'static,
 {
-    type UpdateHandler<C> = MapLaneUpdate<C, K, V>
+    type UpdateHandler<C> = MapLaneUpdate<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
-    type RemoveHandler<C> = MapLaneRemove<C, K, V>
+    type RemoveHandler<C> = MapLaneRemove<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
-    type ClearHandler<C> = MapLaneClear<C, K, V>
+    type ClearHandler<C> = MapLaneClear<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -869,7 +880,7 @@ where
         MapLaneClear::new(projection)
     }
 
-    type TransformEntryHandler<'a, C, F> = MapLaneTransformEntry<C, K, V, F>
+    type TransformEntryHandler<'a, C, F> = MapLaneTransformEntry<C, K, V, F, M>
     where
         Self: 'static,
         C: AgentDescription + 'a,
@@ -917,11 +928,12 @@ impl<C, K, V, F> MapLaneSelectUpdate<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectUpdate<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectUpdate<C, K, V, F>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1000,10 +1012,11 @@ impl<C, K, V, F> MapLaneSelectRemove<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectRemove<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectRemove<C, K, V, F>
 where
     K: Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1075,11 +1088,12 @@ impl<C, K, V, F> MapLaneSelectClear<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectClear<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectClear<C, K, V, F>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1298,11 +1312,12 @@ impl<C, K, V, F> MapLaneSelectSync<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectSync<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectSync<C, K, V, F>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1344,14 +1359,14 @@ where
     }
 }
 
-struct MapLaneRemoveMultiple<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+struct MapLaneRemoveMultiple<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     keys: Option<VecDeque<K>>,
-    current: Option<MapLaneRemove<C, K, V>>,
+    current: Option<MapLaneRemove<C, K, V, M>>,
 }
 
-impl<C, K, V> MapLaneRemoveMultiple<C, K, V> {
-    fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>, keys: VecDeque<K>) -> Self {
+impl<C, K, V, M> MapLaneRemoveMultiple<C, K, V, M> {
+    fn new(projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>, keys: VecDeque<K>) -> Self {
         MapLaneRemoveMultiple {
             projection,
             keys: Some(keys),
@@ -1360,10 +1375,11 @@ impl<C, K, V> MapLaneRemoveMultiple<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneRemoveMultiple<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneRemoveMultiple<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1421,23 +1437,23 @@ enum DropOrTake {
     Take,
 }
 
-enum DropOrTakeState<C, K, V> {
+enum DropOrTakeState<C, K, V, M> {
     Init,
-    Removing(MapLaneRemoveMultiple<C, K, V>),
+    Removing(MapLaneRemoveMultiple<C, K, V, M>),
 }
 
 /// An [event handler](crate::event_handler::EventHandler)`] that will either retain or drop the first `n` elements
 /// from a map (ordering the keys by the ordering of their Recon model representations).
-pub struct MapLaneDropOrTake<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+pub struct MapLaneDropOrTake<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
     kind: DropOrTake,
     number: u64,
-    state: DropOrTakeState<C, K, V>,
+    state: DropOrTakeState<C, K, V, M>,
 }
 
-impl<C, K, V> MapLaneDropOrTake<C, K, V> {
+impl<C, K, V, M> MapLaneDropOrTake<C, K, V, M> {
     fn new(
-        projection: for<'a> fn(&'a C) -> &'a MapLane<K, V>,
+        projection: for<'a> fn(&'a C) -> &'a MapLane<K, V, M>,
         kind: DropOrTake,
         number: u64,
     ) -> Self {
@@ -1450,9 +1466,10 @@ impl<C, K, V> MapLaneDropOrTake<C, K, V> {
     }
 }
 
-fn drop_or_take<K, V>(map: &HashMap<K, V>, kind: DropOrTake, number: usize) -> VecDeque<K>
+fn drop_or_take<K, V, M>(map: &M, kind: DropOrTake, number: usize) -> VecDeque<K>
 where
     K: StructuralWritable + Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     let mut keys_with_recon = map.keys().map(|k| (k.structure(), k)).collect::<Vec<_>>();
     keys_with_recon.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
@@ -1478,10 +1495,11 @@ where
     to_remove
 }
 
-impl<C, K, V> HandlerAction<C> for MapLaneDropOrTake<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapLaneDropOrTake<C, K, V, M>
 where
     C: AgentDescription,
     K: StructuralWritable + Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1558,10 +1576,11 @@ impl<C, K, V, F> MapLaneSelectRemoveMultiple<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectRemoveMultiple<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectRemoveMultiple<C, K, V, F>
 where
     K: Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1632,11 +1651,12 @@ impl<C, K, V, F> MapLaneSelectDropOrTake<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapLaneSelectDropOrTake<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapLaneSelectDropOrTake<C, K, V, F>
 where
     C: AgentDescription,
     K: StructuralWritable + Clone + Eq + Hash,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 

--- a/server/swimos_agent/src/lanes/map/mod.rs
+++ b/server/swimos_agent/src/lanes/map/mod.rs
@@ -381,7 +381,7 @@ where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     V: Clone,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type Completion = Option<V>;
 
@@ -790,7 +790,7 @@ impl<K, V, M> MapLikeItem<K, V, M> for MapLane<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K> + Clone + 'static,
+    M: MapOpsWithEntry<K, V, K> + Clone + 'static,
 {
     type GetHandler<C> = MapLaneGet<C, K, V, M>
     where

--- a/server/swimos_agent/src/lanes/map/mod.rs
+++ b/server/swimos_agent/src/lanes/map/mod.rs
@@ -805,29 +805,26 @@ where
     }
 }
 
-impl<K, V> InspectableMapLikeItem<K, V> for MapLane<K, V>
+impl<K, V, B> InspectableMapLikeItem<K, V, B> for MapLane<K, V>
 where
     K: Eq + Hash + Send + 'static,
-    V: 'static,
+    V: Borrow<B> + 'static,
+    B: ?Sized + 'static,
 {
-    type WithEntryHandler<'a, C, F, B, U> = MapLaneWithEntry<C, K, V, F, B>
+    type WithEntryHandler<'a, C, F, U> = MapLaneWithEntry<C, K, V, F, B>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized +'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 
-    fn with_entry_handler<'a, C, F, B, U>(
+    fn with_entry_handler<'a, C, F, U>(
         projection: fn(&C) -> &Self,
         key: K,
         f: F,
-    ) -> Self::WithEntryHandler<'a, C, F, B, U>
+    ) -> Self::WithEntryHandler<'a, C, F, U>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a,
     {
         MapLaneWithEntry::new(projection, key, f)

--- a/server/swimos_agent/src/lanes/map/mod.rs
+++ b/server/swimos_agent/src/lanes/map/mod.rs
@@ -1151,12 +1151,13 @@ pub enum DecodeAndSelectApply<C, K, V, F> {
     Done,
 }
 
-impl<C, K, V, F> HandlerAction<C> for DecodeAndSelectApply<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for DecodeAndSelectApply<C, K, V, F>
 where
     C: AgentDescription,
     K: Form + Clone + Eq + Hash,
     V: RecognizerReadable,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -1278,14 +1279,15 @@ where
 }
 
 /// Create an event handler that will decode an incoming map message and apply the value into a map lane.
-pub fn decode_and_select_apply<C, K, V, F>(
+pub fn decode_and_select_apply<C, K, V, M, F>(
     message: MapMessage<BytesMut, BytesMut>,
     projection: F,
 ) -> DecodeAndSelectApply<C, K, V, F>
 where
     K: Clone + Eq + Hash + RecognizerReadable,
     V: RecognizerReadable,
-    F: SelectorFn<C, Target = MapLane<K, V>>,
+    F: SelectorFn<C, Target = MapLane<K, V, M>>,
+    M: MapOps<K, V>,
 {
     let decode: DecodeMapMessage<K, V> = DecodeMapMessage::new(message);
     DecodeAndSelectApply::Decoding(decode, projection)

--- a/server/swimos_agent/src/lanes/map/mod.rs
+++ b/server/swimos_agent/src/lanes/map/mod.rs
@@ -134,7 +134,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
         F: FnOnce(Option<&V>) -> R,
-        M: MapOpsWithEntry<K, V, Q, V>,
+        M: MapOpsWithEntry<K, V, Q>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -160,7 +160,7 @@ impl<K, V, M> MapLane<K, V, M> {
         B: ?Sized,
         V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U,
-        M: MapOpsWithEntry<K, V, K, B>,
+        M: MapOpsWithEntry<K, V, K>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -381,7 +381,7 @@ where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     V: Clone,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V>,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K>,
 {
     type Completion = Option<V>;
 
@@ -495,7 +495,7 @@ where
     B: ?Sized,
     V: Borrow<B>,
     F: FnOnce(Option<&B>) -> U,
-    M: MapOpsWithEntry<K, V, K, B>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type Completion = U;
 
@@ -790,7 +790,7 @@ impl<K, V, M> MapLikeItem<K, V, M> for MapLane<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V> + Clone + 'static,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K> + Clone + 'static,
 {
     type GetHandler<C> = MapLaneGet<C, K, V, M>
     where
@@ -819,7 +819,7 @@ where
     K: Eq + Hash + Send + 'static,
     V: Borrow<B> + 'static,
     B: ?Sized + 'static,
-    M: MapOpsWithEntry<K, V, K, B>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type WithEntryHandler<'a, C, F, U> = MapLaneWithEntry<C, K, V, F, B, M>
     where

--- a/server/swimos_agent/src/lanes/map/tests.rs
+++ b/server/swimos_agent/src/lanes/map/tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt::Debug;
 
 use bytes::BytesMut;
@@ -1122,35 +1122,75 @@ fn drop_take_choose_keys() {
         .collect::<HashMap<_, _>>();
 
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Drop, 2),
+        drop_or_take(&map, DropOrTake::Drop, 2),
         VecDeque::from(vec![1, 2])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Take, 3),
+        drop_or_take(&map, DropOrTake::Take, 3),
         VecDeque::from(vec![4])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Drop, 4),
+        drop_or_take(&map, DropOrTake::Drop, 4),
         VecDeque::from(vec![1, 2, 3, 4])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Take, 4),
+        drop_or_take(&map, DropOrTake::Take, 4),
         VecDeque::from(vec![])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Drop, 10),
+        drop_or_take(&map, DropOrTake::Drop, 10),
         VecDeque::from(vec![1, 2, 3, 4])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Take, 10),
+        drop_or_take(&map, DropOrTake::Take, 10),
         VecDeque::from(vec![])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Drop, 0),
+        drop_or_take(&map, DropOrTake::Drop, 0),
         VecDeque::from(vec![])
     );
     assert_eq!(
-        drop_or_take(&map, super::DropOrTake::Take, 0),
+        drop_or_take(&map, DropOrTake::Take, 0),
+        VecDeque::from(vec![1, 2, 3, 4])
+    );
+}
+
+#[test]
+fn drop_take_choose_keys_ordered() {
+    let map = [(1, 2), (2, 4), (3, 6), (4, 8)]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Drop, 2),
+        VecDeque::from(vec![1, 2])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Take, 3),
+        VecDeque::from(vec![4])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Drop, 4),
+        VecDeque::from(vec![1, 2, 3, 4])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Take, 4),
+        VecDeque::from(vec![])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Drop, 10),
+        VecDeque::from(vec![1, 2, 3, 4])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Take, 10),
+        VecDeque::from(vec![])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Drop, 0),
+        VecDeque::from(vec![])
+    );
+    assert_eq!(
+        drop_or_take(&map, DropOrTake::Take, 0),
         VecDeque::from(vec![1, 2, 3, 4])
     );
 }

--- a/server/swimos_agent/src/lanes/queues/mod.rs
+++ b/server/swimos_agent/src/lanes/queues/mod.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::hash::Hash;
 
 use swimos_agent_protocol::{LaneResponse, MapOperation};
 use uuid::Uuid;
 
 use crate::event_queue::{to_operation, EventQueue};
-use crate::map_storage::MapEventQueue;
+use crate::map_storage::{MapEventQueue, MapOps};
 
 /// For a sync operation on a map lane, keeps track of which keys are synced for a given remote.
 #[derive(Debug)]
@@ -202,7 +202,11 @@ where
         self.push_operation(action)
     }
 
-    fn pop<'a>(&mut self, content: &'a HashMap<K, V>) -> Option<Self::Output<'a>> {
+    fn pop<'a, M>(&mut self, content: &'a M) -> Option<Self::Output<'a>>
+    where
+        K: 'a,
+        M: MapOps<K, V>,
+    {
         loop {
             match WriteQueues::pop(self)? {
                 ToWrite::Event(action) => {

--- a/server/swimos_agent/src/lib.rs
+++ b/server/swimos_agent/src/lib.rs
@@ -83,6 +83,9 @@ pub use item::AgentItem;
 pub use meta::AgentMetadata;
 
 #[doc(hidden)]
+pub use map_storage::MapBacking;
+
+#[doc(hidden)]
 pub mod model {
     pub use swimos_agent_protocol::{MapMessage, MapOperation};
     pub use swimos_api::agent::HttpLaneRequest;

--- a/server/swimos_agent/src/map_storage/mod.rs
+++ b/server/swimos_agent/src/map_storage/mod.rs
@@ -193,6 +193,23 @@ where
     }
 }
 
+impl<K, V, BK, BV> MapOpsWithEntry<K, V, BK, BV> for BTreeMap<K, V>
+where
+    BK: ?Sized,
+    BV: ?Sized,
+    K: Ord,
+    BK: Ord,
+{
+    fn with_item<F, R>(&self, key: &BK, f: F) -> R
+    where
+        K: Borrow<BK>,
+        V: Borrow<BV>,
+        F: FnOnce(Option<&BV>) -> R,
+    {
+        f(self.get(key).map(Borrow::borrow))
+    }
+}
+
 impl<K, V, Q, M> MapStoreInner<K, V, Q, M>
 where
     K: Clone,

--- a/server/swimos_agent/src/map_storage/mod.rs
+++ b/server/swimos_agent/src/map_storage/mod.rs
@@ -92,6 +92,9 @@ pub trait MapOps<K, V> {
     fn keys<'a>(&'a self) -> impl Iterator<Item = &'a K>
     where
         K: 'a;
+    fn from_entries<I>(it: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>;
 }
 
 pub trait MapOpsWithEntry<K, V, BK: ?Sized, BV: ?Sized> {
@@ -129,6 +132,13 @@ where
     {
         HashMap::keys(self)
     }
+
+    fn from_entries<I>(it: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        it.into_iter().collect()
+    }
 }
 
 impl<K, V> MapOps<K, V> for BTreeMap<K, V>
@@ -156,6 +166,13 @@ where
         K: 'a,
     {
         BTreeMap::keys(self)
+    }
+
+    fn from_entries<I>(it: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        it.into_iter().collect()
     }
 }
 

--- a/server/swimos_agent/src/map_storage/mod.rs
+++ b/server/swimos_agent/src/map_storage/mod.rs
@@ -89,6 +89,9 @@ pub trait MapOps<K, V> {
     fn insert(&mut self, key: K, value: V) -> Option<V>;
     fn remove(&mut self, key: &K) -> Option<V>;
     fn take(&mut self) -> Self;
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a K>
+    where
+        K: 'a;
 }
 
 pub trait MapOpsWithEntry<K, V, BK: ?Sized, BV: ?Sized> {
@@ -119,6 +122,13 @@ where
     fn take(&mut self) -> Self {
         std::mem::take(self)
     }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a K>
+    where
+        K: 'a,
+    {
+        HashMap::keys(self)
+    }
 }
 
 impl<K, V> MapOps<K, V> for BTreeMap<K, V>
@@ -139,6 +149,13 @@ where
 
     fn take(&mut self) -> Self {
         std::mem::take(self)
+    }
+
+    fn keys<'a>(&'a self) -> impl Iterator<Item = &'a K>
+    where
+        K: 'a,
+    {
+        BTreeMap::keys(self)
     }
 }
 

--- a/server/swimos_agent/src/map_storage/mod.rs
+++ b/server/swimos_agent/src/map_storage/mod.rs
@@ -93,6 +93,7 @@ pub trait MapOps<K, V> {
     fn keys<'a>(&'a self) -> impl Iterator<Item = &'a K>
     where
         K: 'a;
+    const ORDERED_KEYS: bool;
     fn from_entries<I>(it: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>;
@@ -139,6 +140,8 @@ where
     {
         it.into_iter().collect()
     }
+
+    const ORDERED_KEYS: bool = false;
 }
 
 impl<K, V> MapOps<K, V> for BTreeMap<K, V>
@@ -174,6 +177,8 @@ where
     {
         it.into_iter().collect()
     }
+
+    const ORDERED_KEYS: bool = true;
 }
 
 impl<K, V, BK> MapOpsWithEntry<K, V, BK> for HashMap<K, V>

--- a/server/swimos_agent/src/map_storage/mod.rs
+++ b/server/swimos_agent/src/map_storage/mod.rs
@@ -223,7 +223,13 @@ where
             queue.push(MapOperation::Remove { key: key.clone() });
         }
     }
+}
 
+impl<K, V, Q, M> MapStoreInner<K, V, Q, M>
+where
+    Q: MapEventQueue<K, V>,
+    M: MapOps<K, V>,
+{
     pub fn clear(&mut self) {
         let MapStoreInner {
             content,

--- a/server/swimos_agent/src/stores/map/mod.rs
+++ b/server/swimos_agent/src/stores/map/mod.rs
@@ -29,7 +29,8 @@ use crate::agent_model::{AgentDescription, WriteResult};
 use crate::event_handler::{ActionContext, HandlerAction, Modification, StepResult};
 use crate::event_queue::EventQueue;
 use crate::item::{AgentItem, InspectableMapLikeItem, MapItem, MapLikeItem, MutableMapLikeItem};
-use crate::map_storage::{MapStoreInner, TransformEntryResult};
+use crate::lanes::map::MapLaneEvent;
+use crate::map_storage::{MapOps, MapOpsWithEntry, MapStoreInner, TransformEntryResult};
 use crate::meta::AgentMetadata;
 
 use super::StoreItem;
@@ -37,24 +38,24 @@ use super::StoreItem;
 #[cfg(test)]
 mod tests;
 
-type Inner<K, V> = MapStoreInner<K, V, EventQueue<K, ()>>;
+type Inner<K, V, M> = MapStoreInner<K, V, EventQueue<K, ()>, M>;
 
 /// Adding a [`MapStore`] to an agent provides additional state that is not exposed as a lane.
 /// If persistence is enabled (and the store is not marked as transient) the state of the store
 /// will be persisted in the same way as the state of a lane.
 #[derive(Debug)]
-pub struct MapStore<K, V> {
+pub struct MapStore<K, V, M = HashMap<K, V>> {
     id: u64,
-    inner: RefCell<Inner<K, V>>,
+    inner: RefCell<Inner<K, V, M>>,
 }
 
 assert_impl_all!(MapStore<(), ()>: Send);
 
-impl<K, V> MapStore<K, V> {
+impl<K, V, M> MapStore<K, V, M> {
     /// # Arguments
     /// * `id` - The ID of the store. This should be unique within an agent.
     /// * `init` - The initial contents of the map.
-    pub fn new(id: u64, init: HashMap<K, V>) -> Self {
+    pub fn new(id: u64, init: M) -> Self {
         MapStore {
             id,
             inner: RefCell::new(Inner::new(init)),
@@ -62,31 +63,33 @@ impl<K, V> MapStore<K, V> {
     }
 }
 
-impl<K, V> AgentItem for MapStore<K, V> {
+impl<K, V, M> AgentItem for MapStore<K, V, M> {
     fn id(&self) -> u64 {
         self.id
     }
 }
 
-impl<K, V> MapItem<K, V> for MapStore<K, V>
+impl<K, V, M> MapItem<K, V, M> for MapStore<K, V, M>
 where
-    K: Eq + Hash + Clone,
+    K: Hash + Eq + Clone,
+    M: MapOps<K, V>,
 {
-    fn init(&self, map: HashMap<K, V>) {
+    fn init(&self, map: M) {
         self.inner.borrow_mut().init(map)
     }
 
     fn read_with_prev<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(Option<crate::lanes::map::MapLaneEvent<K, V>>, &HashMap<K, V>) -> R,
+        F: FnOnce(Option<MapLaneEvent<K, V, M>>, &M) -> R,
     {
         self.inner.borrow_mut().read_with_prev(f)
     }
 }
 
-impl<K, V> MapStore<K, V>
+impl<K, V, M> MapStore<K, V, M>
 where
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     /// Update the value associated with a key.
     pub fn update(&self, key: K, value: V) {
@@ -111,37 +114,36 @@ where
         self.inner.borrow_mut().clear()
     }
 
-    /// Read a value from the map, if it exists.
-    pub fn get<Q, F, R>(&self, key: &Q, f: F) -> R
-    where
-        K: Borrow<Q> + Eq + Hash,
-        Q: Eq + Hash,
-        F: FnOnce(Option<&V>) -> R,
-    {
-        self.inner.borrow().with_entry(key, f)
-    }
-
     /// Read the complete state of the map.
     pub fn get_map<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&HashMap<K, V>) -> R,
+        F: FnOnce(&M) -> R,
     {
         self.inner.borrow().get_map(f)
     }
 }
 
-impl<K, V> MapStore<K, V>
-where
-    K: Eq + Hash,
-{
+impl<K, V, M> MapStore<K, V, M> {
+    /// Read a value from the map, if it exists.
+    pub fn get<Q, F, R>(&self, key: &Q, f: F) -> R
+    where
+        K: Borrow<Q>,
+        F: FnOnce(Option<&V>) -> R,
+        M: MapOpsWithEntry<K, V, Q, V>,
+    {
+        self.inner.borrow().with_entry(key, f)
+    }
+}
+
+impl<K, V, M> MapStore<K, V, M> {
     pub fn with_entry<F, B1, B2, U>(&self, key: &B1, f: F) -> U
     where
         B1: ?Sized,
         B2: ?Sized,
         K: Borrow<B1>,
-        B1: Eq + Hash,
         V: Borrow<B2>,
         F: FnOnce(Option<&B2>) -> U,
+        M: MapOpsWithEntry<K, V, B1, B2>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -149,10 +151,11 @@ where
 
 const INFALLIBLE_SER: &str = "Serializing store responses to recon should be infallible.";
 
-impl<K, V> StoreItem for MapStore<K, V>
+impl<K, V, M> StoreItem for MapStore<K, V, M>
 where
     K: Clone + Eq + Hash + StructuralWritable + 'static,
     V: StructuralWritable + 'static,
+    M: MapOps<K, V>,
 {
     fn write_to_buffer(&self, buffer: &mut BytesMut) -> WriteResult {
         let mut encoder = MapStoreResponseEncoder::default();
@@ -171,13 +174,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will update the value of an entry in the map.
-pub struct MapStoreUpdate<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreUpdate<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     key_value: Option<(K, V)>,
 }
 
-impl<C, K, V> MapStoreUpdate<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>, key: K, value: V) -> Self {
+impl<C, K, V, M> MapStoreUpdate<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>, key: K, value: V) -> Self {
         MapStoreUpdate {
             projection,
             key_value: Some((key, value)),
@@ -185,10 +188,11 @@ impl<C, K, V> MapStoreUpdate<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapStoreUpdate<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapStoreUpdate<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -230,13 +234,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will remove an entry from the map.
-pub struct MapStoreRemove<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreRemove<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     key: Option<K>,
 }
 
-impl<C, K, V> MapStoreRemove<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>, key: K) -> Self {
+impl<C, K, V, M> MapStoreRemove<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>, key: K) -> Self {
         MapStoreRemove {
             projection,
             key: Some(key),
@@ -244,10 +248,11 @@ impl<C, K, V> MapStoreRemove<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapStoreRemove<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapStoreRemove<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -283,13 +288,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will clear the map.
-pub struct MapStoreClear<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreClear<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     done: bool,
 }
 
-impl<C, K, V> MapStoreClear<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>) -> Self {
+impl<C, K, V, M> MapStoreClear<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>) -> Self {
         MapStoreClear {
             projection,
             done: false,
@@ -297,10 +302,11 @@ impl<C, K, V> MapStoreClear<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapStoreClear<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapStoreClear<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -337,14 +343,14 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will get an entry from the map.
-pub struct MapStoreGet<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreGet<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     key: K,
     done: bool,
 }
 
-impl<C, K, V> MapStoreGet<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>, key: K) -> Self {
+impl<C, K, V, M> MapStoreGet<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>, key: K) -> Self {
         MapStoreGet {
             projection,
             key,
@@ -353,11 +359,11 @@ impl<C, K, V> MapStoreGet<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapStoreGet<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapStoreGet<C, K, V, M>
 where
     C: AgentDescription,
-    K: Clone + Eq + Hash,
     V: Clone,
+    M: MapOpsWithEntry<K, V, K, V>,
 {
     type Completion = Option<V>;
 
@@ -375,7 +381,7 @@ where
         if !*done {
             *done = true;
             let store = projection(context);
-            StepResult::done(store.get(key, |v| v.cloned()))
+            StepResult::done(MapStore::get(store, key, |v| v.cloned()))
         } else {
             StepResult::after_done()
         }
@@ -393,13 +399,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that will read the entire state of a map store.
-pub struct MapStoreGetMap<C, K, V> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreGetMap<C, K, V, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     done: bool,
 }
 
-impl<C, K, V> MapStoreGetMap<C, K, V> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>) -> Self {
+impl<C, K, V, M> MapStoreGetMap<C, K, V, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>) -> Self {
         MapStoreGetMap {
             projection,
             done: false,
@@ -407,13 +413,14 @@ impl<C, K, V> MapStoreGetMap<C, K, V> {
     }
 }
 
-impl<C, K, V> HandlerAction<C> for MapStoreGetMap<C, K, V>
+impl<C, K, V, M> HandlerAction<C> for MapStoreGetMap<C, K, V, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     V: Clone,
+    M: MapOps<K, V> + Clone,
 {
-    type Completion = HashMap<K, V>;
+    type Completion = M;
 
     fn step(
         &mut self,
@@ -443,13 +450,13 @@ where
 }
 
 ///  An [event handler](crate::event_handler::EventHandler)`] that may alter an entry in the map.
-pub struct MapStoreTransformEntry<C, K, V, F> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreTransformEntry<C, K, V, F, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     key_and_f: Option<(K, F)>,
 }
 
-impl<C, K, V, F> MapStoreTransformEntry<C, K, V, F> {
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>, key: K, f: F) -> Self {
+impl<C, K, V, F, M> MapStoreTransformEntry<C, K, V, F, M> {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>, key: K, f: F) -> Self {
         MapStoreTransformEntry {
             projection,
             key_and_f: Some((key, f)),
@@ -457,11 +464,12 @@ impl<C, K, V, F> MapStoreTransformEntry<C, K, V, F> {
     }
 }
 
-impl<C, K, V, F> HandlerAction<C> for MapStoreTransformEntry<C, K, V, F>
+impl<C, K, V, F, M> HandlerAction<C> for MapStoreTransformEntry<C, K, V, F, M>
 where
     C: AgentDescription,
     K: Clone + Eq + Hash,
     F: FnOnce(Option<&V>) -> Option<V>,
+    M: MapOps<K, V>,
 {
     type Completion = ();
 
@@ -511,18 +519,18 @@ where
 
 /// A [handler action][`HandlerAction`] that will produce a value by applying a closure to a reference to
 /// and entry in the store.
-pub struct MapStoreWithEntry<C, K, V, F, B: ?Sized> {
-    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>,
+pub struct MapStoreWithEntry<C, K, V, F, B: ?Sized, M = HashMap<K, V>> {
+    projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>,
     key_and_f: Option<(K, F)>,
     _type: PhantomData<fn(&B)>,
 }
 
-impl<C, K, V, F, B: ?Sized> MapStoreWithEntry<C, K, V, F, B> {
+impl<C, K, V, F, B: ?Sized, M> MapStoreWithEntry<C, K, V, F, B, M> {
     /// #Arguments
     /// * `projection` - Projection from the agent context to the store.
     /// * `key` - Key of the entry.
     /// * `f` - The closure to apply to the entry.
-    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V>, key: K, f: F) -> Self {
+    pub fn new(projection: for<'a> fn(&'a C) -> &'a MapStore<K, V, M>, key: K, f: F) -> Self {
         MapStoreWithEntry {
             projection,
             key_and_f: Some((key, f)),
@@ -531,13 +539,13 @@ impl<C, K, V, F, B: ?Sized> MapStoreWithEntry<C, K, V, F, B> {
     }
 }
 
-impl<C, K, V, F, B, U> HandlerAction<C> for MapStoreWithEntry<C, K, V, F, B>
+impl<C, K, V, F, B, U, M> HandlerAction<C> for MapStoreWithEntry<C, K, V, F, B, M>
 where
     C: AgentDescription,
-    K: Eq + Hash,
     B: ?Sized,
     V: Borrow<B>,
     F: FnOnce(Option<&B>) -> U,
+    M: MapOpsWithEntry<K, V, K, B>,
 {
     type Completion = U;
 
@@ -571,12 +579,13 @@ where
             .finish()
     }
 }
-impl<K, V> MapLikeItem<K, V> for MapStore<K, V>
+impl<K, V, M> MapLikeItem<K, V, M> for MapStore<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V> + Clone + 'static,
 {
-    type GetHandler<C> = MapStoreGet<C, K, V>
+    type GetHandler<C> = MapStoreGet<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -587,7 +596,7 @@ where
         MapStoreGet::new(projection, key)
     }
 
-    type GetMapHandler<C> = MapStoreGetMap<C, K, V>
+    type GetMapHandler<C> = MapStoreGetMap<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -598,49 +607,48 @@ where
     }
 }
 
-impl<K, V> InspectableMapLikeItem<K, V> for MapStore<K, V>
+impl<K, V, M, B> InspectableMapLikeItem<K, V, B> for MapStore<K, V, M>
 where
-    K: Eq + Hash + Send + 'static,
-    V: 'static,
+    K: Send + 'static,
+    V: Borrow<B> + 'static,
+    B: ?Sized + 'static,
+    M: MapOpsWithEntry<K, V, K, B>,
 {
-    type WithEntryHandler<'a, C, F, B, U> = MapStoreWithEntry<C, K, V, F, B>
+    type WithEntryHandler<'a, C, F, U> = MapStoreWithEntry<C, K, V, F, B, M>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized +'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a;
 
-    fn with_entry_handler<'a, C, F, B, U>(
+    fn with_entry_handler<'a, C, F, U>(
         projection: fn(&C) -> &Self,
         key: K,
         f: F,
-    ) -> Self::WithEntryHandler<'a, C, F, B, U>
+    ) -> Self::WithEntryHandler<'a, C, F, U>
     where
         Self: 'static,
         C: AgentDescription + 'a,
-        B: ?Sized + 'static,
-        V: Borrow<B>,
         F: FnOnce(Option<&B>) -> U + Send + 'a,
     {
         MapStoreWithEntry::new(projection, key, f)
     }
 }
 
-impl<K, V> MutableMapLikeItem<K, V> for MapStore<K, V>
+impl<K, V, M> MutableMapLikeItem<K, V> for MapStore<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Send + 'static,
+    M: MapOps<K, V> + 'static,
 {
-    type UpdateHandler<C> = MapStoreUpdate<C, K, V>
+    type UpdateHandler<C> = MapStoreUpdate<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
-    type RemoveHandler<C> = MapStoreRemove<C, K, V>
+    type RemoveHandler<C> = MapStoreRemove<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
-    type ClearHandler<C> = MapStoreClear<C, K, V>
+    type ClearHandler<C> = MapStoreClear<C, K, V, M>
     where
         C: AgentDescription + 'static;
 
@@ -665,7 +673,7 @@ where
         MapStoreClear::new(projection)
     }
 
-    type TransformEntryHandler<'a, C, F> = MapStoreTransformEntry<C, K, V, F>
+    type TransformEntryHandler<'a, C, F> = MapStoreTransformEntry<C, K, V, F, M>
     where
         Self: 'static,
         C: AgentDescription + 'a,

--- a/server/swimos_agent/src/stores/map/mod.rs
+++ b/server/swimos_agent/src/stores/map/mod.rs
@@ -583,7 +583,7 @@ impl<K, V, M> MapLikeItem<K, V, M> for MapStore<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K> + Clone + 'static,
+    M: MapOpsWithEntry<K, V, K> + Clone + 'static,
 {
     type GetHandler<C> = MapStoreGet<C, K, V, M>
     where

--- a/server/swimos_agent/src/stores/map/mod.rs
+++ b/server/swimos_agent/src/stores/map/mod.rs
@@ -129,7 +129,7 @@ impl<K, V, M> MapStore<K, V, M> {
     where
         K: Borrow<Q>,
         F: FnOnce(Option<&V>) -> R,
-        M: MapOpsWithEntry<K, V, Q, V>,
+        M: MapOpsWithEntry<K, V, Q>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -143,7 +143,7 @@ impl<K, V, M> MapStore<K, V, M> {
         K: Borrow<B1>,
         V: Borrow<B2>,
         F: FnOnce(Option<&B2>) -> U,
-        M: MapOpsWithEntry<K, V, B1, B2>,
+        M: MapOpsWithEntry<K, V, B1>,
     {
         self.inner.borrow().with_entry(key, f)
     }
@@ -363,7 +363,7 @@ impl<C, K, V, M> HandlerAction<C> for MapStoreGet<C, K, V, M>
 where
     C: AgentDescription,
     V: Clone,
-    M: MapOpsWithEntry<K, V, K, V>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type Completion = Option<V>;
 
@@ -545,7 +545,7 @@ where
     B: ?Sized,
     V: Borrow<B>,
     F: FnOnce(Option<&B>) -> U,
-    M: MapOpsWithEntry<K, V, K, B>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type Completion = U;
 
@@ -583,7 +583,7 @@ impl<K, V, M> MapLikeItem<K, V, M> for MapStore<K, V, M>
 where
     K: Clone + Eq + Hash + Send + 'static,
     V: Clone + 'static,
-    M: MapOps<K, V> + MapOpsWithEntry<K, V, K, V> + Clone + 'static,
+    M: MapOps<K, V> + MapOpsWithEntry<K, V, K> + Clone + 'static,
 {
     type GetHandler<C> = MapStoreGet<C, K, V, M>
     where
@@ -612,7 +612,7 @@ where
     K: Send + 'static,
     V: Borrow<B> + 'static,
     B: ?Sized + 'static,
-    M: MapOpsWithEntry<K, V, K, B>,
+    M: MapOpsWithEntry<K, V, K>,
 {
     type WithEntryHandler<'a, C, F, U> = MapStoreWithEntry<C, K, V, F, B, M>
     where

--- a/server/swimos_agent_derive/src/agent_lifecycle/mod.rs
+++ b/server/swimos_agent_derive/src/agent_lifecycle/mod.rs
@@ -170,7 +170,7 @@ impl<'a> LaneLifecycleBuilder<'a> {
                 ..
             }) => {
                 let mut builder: syn::Expr = parse_quote! {
-                    <#root::lanes::map::lifecycle::StatefulMapLaneLifecycle::<#agent_type, #lifecycle_type, _, _> as ::core::default::Default>::default()
+                    <#root::lanes::map::lifecycle::StatefulMapLaneLifecycle::<#agent_type, #lifecycle_type, _, _, _> as ::core::default::Default>::default()
                 };
                 if let Some(handler) = on_update {
                     builder = parse_quote! {

--- a/server/swimos_agent_derive/src/lane_model_derive/mod.rs
+++ b/server/swimos_agent_derive/src/lane_model_derive/mod.rs
@@ -569,7 +569,7 @@ impl<'a> WarpLaneHandlerMatch<'a> {
                 quote!(#root::lanes::value::decode_and_set::<#agent_name, #ty>(body, |agent: &#agent_name| &agent.#name))
             }
             WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, ::std::collections::HashMap<#k, #v>>(body, |agent: &#agent_name| &agent.#name))
+                quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, _>(body, |agent: &#agent_name| &agent.#name))
             }
             WarpLaneSpec::Demand(_)
             | WarpLaneSpec::DemandMap(_, _)

--- a/server/swimos_agent_derive/src/lane_model_derive/mod.rs
+++ b/server/swimos_agent_derive/src/lane_model_derive/mod.rs
@@ -345,7 +345,7 @@ impl<'a> OrdinalWarpLaneModel<'a> {
     pub fn map_like(&self) -> bool {
         matches!(
             &self.model.kind,
-            WarpLaneSpec::Map(_, _)
+            WarpLaneSpec::Map(_, _, _)
                 | WarpLaneSpec::DemandMap(_, _)
                 | WarpLaneSpec::JoinValue(_, _)
                 | WarpLaneSpec::JoinMap(_, _, _)
@@ -391,7 +391,7 @@ impl<'a> OrdinalItemModel<'a> {
 
     fn category(&self) -> ItemCategory {
         match &self.model.kind {
-            ItemSpec::Map(_, _, _)
+            ItemSpec::Map(_, _, _, _)
             | ItemSpec::JoinValue(_, _)
             | ItemSpec::JoinMap(_, _, _)
             | ItemSpec::DemandMap(_, _) => ItemCategory::MapLike,
@@ -430,10 +430,10 @@ impl<'a> FieldInitializer<'a> {
             ItemSpec::Value(ItemKind::Store, _) => {
                 quote!(#name: #root::stores::ValueStore::new(#ordinal, ::core::default::Default::default()))
             }
-            ItemSpec::Map(ItemKind::Lane, _, _) => {
+            ItemSpec::Map(ItemKind::Lane, _, _, _) => {
                 quote!(#name: #root::lanes::MapLane::new(#ordinal, ::core::default::Default::default()))
             }
-            ItemSpec::Map(ItemKind::Store, _, _) => {
+            ItemSpec::Map(ItemKind::Store, _, _, _) => {
                 quote!(#name: #root::stores::MapStore::new(#ordinal, ::core::default::Default::default()))
             }
             ItemSpec::JoinValue(_, _) => {
@@ -470,8 +470,12 @@ impl<'a> HandlerType<'a> {
             WarpLaneSpec::Value(t) => {
                 quote!(#root::lanes::value::DecodeAndSet<#agent_name, #t>)
             }
-            WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::DecodeAndApply<#agent_name, #k, #v>)
+            WarpLaneSpec::Map(k, v, m) => {
+                if let Some(map_t) = m {
+                    quote!(#root::lanes::map::DecodeAndApply<#agent_name, #k, #v, #map_t>)
+                } else {
+                    quote!(#root::lanes::map::DecodeAndApply<#agent_name, #k, #v>)
+                }
             }
             WarpLaneSpec::Demand(_)
             | WarpLaneSpec::DemandMap(_, _)
@@ -503,8 +507,12 @@ impl<'a> SyncHandlerType<'a> {
             WarpLaneSpec::Value(t) => {
                 quote!(#root::lanes::value::ValueLaneSync<#agent_name, #t>)
             }
-            WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::MapLaneSync<#agent_name, #k, #v>)
+            WarpLaneSpec::Map(k, v, m) => {
+                if let Some(map_t) = m {
+                    quote!(#root::lanes::map::MapLaneSync<#agent_name, #k, #v, #map_t>)
+                } else {
+                    quote!(#root::lanes::map::MapLaneSync<#agent_name, #k, #v>)
+                }
             }
             WarpLaneSpec::JoinValue(k, v) => {
                 quote!(#root::lanes::join_value::JoinValueLaneSync<#agent_name, #k, #v>)
@@ -568,8 +576,12 @@ impl<'a> WarpLaneHandlerMatch<'a> {
             WarpLaneSpec::Value(ty) => {
                 quote!(#root::lanes::value::decode_and_set::<#agent_name, #ty>(body, |agent: &#agent_name| &agent.#name))
             }
-            WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, _>(body, |agent: &#agent_name| &agent.#name))
+            WarpLaneSpec::Map(k, v, m) => {
+                if let Some(map_t) = m {
+                    quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, #map_t>(body, |agent: &#agent_name| &agent.#name))
+                } else {
+                    quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, _>(body, |agent: &#agent_name| &agent.#name))
+                }
             }
             WarpLaneSpec::Demand(_)
             | WarpLaneSpec::DemandMap(_, _)
@@ -672,8 +684,12 @@ impl<'a> SyncHandlerMatch<'a> {
             WarpLaneSpec::Value(ty) => {
                 quote!(#root::lanes::value::ValueLaneSync::<#agent_name, #ty>::new(|agent: &#agent_name| &agent.#name, id))
             }
-            WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::MapLaneSync::<#agent_name, #k, #v>::new(|agent: &#agent_name| &agent.#name, id))
+            WarpLaneSpec::Map(k, v, m) => {
+                if let Some(map_t) = m {
+                    quote!(#root::lanes::map::MapLaneSync::<#agent_name, #k, #v, #map_t>::new(|agent: &#agent_name| &agent.#name, id))
+                } else {
+                    quote!(#root::lanes::map::MapLaneSync::<#agent_name, #k, #v>::new(|agent: &#agent_name| &agent.#name, id))
+                }
             }
             WarpLaneSpec::JoinValue(k, v) => {
                 quote!(#root::lanes::join_value::JoinValueLaneSync::<#agent_name, #k, #v>::new(|agent: &#agent_name| &agent.#name, id))
@@ -764,7 +780,7 @@ struct MapItemInitMatch<'a> {
 impl<'a> MapItemInitMatch<'a> {
     pub fn new(item: &OrdinalItemModel<'a>) -> Self {
         let init_kind = match &item.model.kind {
-            ItemSpec::Map(ItemKind::Lane, _, _) => InitKind::MapLane,
+            ItemSpec::Map(ItemKind::Lane, _, _, _) => InitKind::MapLane,
             _ => InitKind::MapStore,
         };
         MapItemInitMatch {
@@ -822,10 +838,10 @@ impl<'a> LaneSpecInsert<'a> {
             ItemSpec::Value(ItemKind::Store, _) => {
                 quote!(#root::agent_model::ItemDescriptor::Store { kind: #root::agent_model::StoreKind::Value, flags: #flags })
             }
-            ItemSpec::Map(ItemKind::Lane, _, _) => {
+            ItemSpec::Map(ItemKind::Lane, _, _, _) => {
                 quote!(#root::agent_model::ItemDescriptor::WarpLane { kind: #root::agent_model::WarpLaneKind::Map, flags: #flags })
             }
-            ItemSpec::Map(ItemKind::Store, _, _) => {
+            ItemSpec::Map(ItemKind::Store, _, _, _) => {
                 quote!(#root::agent_model::ItemDescriptor::Store { kind: #root::agent_model::StoreKind::Map, flags: #flags })
             }
             ItemSpec::JoinValue(_, _) => {

--- a/server/swimos_agent_derive/src/lane_model_derive/mod.rs
+++ b/server/swimos_agent_derive/src/lane_model_derive/mod.rs
@@ -569,7 +569,7 @@ impl<'a> WarpLaneHandlerMatch<'a> {
                 quote!(#root::lanes::value::decode_and_set::<#agent_name, #ty>(body, |agent: &#agent_name| &agent.#name))
             }
             WarpLaneSpec::Map(k, v) => {
-                quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v>(body, |agent: &#agent_name| &agent.#name))
+                quote!(#root::lanes::map::decode_and_apply::<#agent_name, #k, #v, ::std::collections::HashMap<#k, #v>>(body, |agent: &#agent_name| &agent.#name))
             }
             WarpLaneSpec::Demand(_)
             | WarpLaneSpec::DemandMap(_, _)

--- a/swimos/tests/deriveagentlanemodel.rs
+++ b/swimos/tests/deriveagentlanemodel.rs
@@ -844,3 +844,23 @@ fn agent_level_transient_flag() {
         transient_store(3, "fourth", StoreKind::Value),
     ]);
 }
+
+#[test]
+fn map_lane_explicit_backing() {
+    #[derive(AgentLaneModel)]
+    struct MapLaneExplicit {
+        lane: MapLane<i32, i32, HashMap<i32, i32>>,
+    }
+
+    check_agent::<MapLaneExplicit>(vec![persistent_lane(0, "lane", WarpLaneKind::Map)]);
+}
+
+#[test]
+fn map_store_explicit_backing() {
+    #[derive(AgentLaneModel)]
+    struct MapStoreExplicit {
+        store: MapStore<i32, i32, HashMap<i32, i32>>,
+    }
+
+    check_agent::<MapStoreExplicit>(vec![persistent_store(0, "store", StoreKind::Map)]);
+}

--- a/swimos/tests/deriveagentlanemodel.rs
+++ b/swimos/tests/deriveagentlanemodel.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
 
 use swimos::agent::agent_model::ItemFlags;
@@ -849,7 +849,7 @@ fn agent_level_transient_flag() {
 fn map_lane_explicit_backing() {
     #[derive(AgentLaneModel)]
     struct MapLaneExplicit {
-        lane: MapLane<i32, i32, HashMap<i32, i32>>,
+        lane: MapLane<i32, String, HashMap<i32, String>>,
     }
 
     check_agent::<MapLaneExplicit>(vec![persistent_lane(0, "lane", WarpLaneKind::Map)]);
@@ -859,8 +859,28 @@ fn map_lane_explicit_backing() {
 fn map_store_explicit_backing() {
     #[derive(AgentLaneModel)]
     struct MapStoreExplicit {
-        store: MapStore<i32, i32, HashMap<i32, i32>>,
+        store: MapStore<i32, String, HashMap<i32, String>>,
     }
 
     check_agent::<MapStoreExplicit>(vec![persistent_store(0, "store", StoreKind::Map)]);
+}
+
+#[test]
+fn map_lane_ordered_map() {
+    #[derive(AgentLaneModel)]
+    struct MapLaneOrdered {
+        lane: MapLane<i32, String, BTreeMap<i32, String>>,
+    }
+
+    check_agent::<MapLaneOrdered>(vec![persistent_lane(0, "lane", WarpLaneKind::Map)]);
+}
+
+#[test]
+fn map_store_ordered_map() {
+    #[derive(AgentLaneModel)]
+    struct MapStoreOrdered {
+        store: MapStore<i32, String, BTreeMap<i32, String>>,
+    }
+
+    check_agent::<MapStoreOrdered>(vec![persistent_store(0, "store", StoreKind::Map)]);
 }


### PR DESCRIPTION
It is now possible to change the underlying map used by `MapStore` and `MapLane`. This allows:

1. `MapLane<K, V, HashMap<K, V, S>>` - Specifying a custom hash implementation for hash maps.
2. `MapLane<K, V, BTreeMap<K, V>>` - Specifying an ordered standard library B-tree map.

This behaviour is enabled by two new traits `swimos_agen::map_storage::MapOps` and `swimos_agen::map_storage::MapOpsWithEntry`. Currently these are only implement for the standard library `HashMap` and `BTreeMap` types and are not exposed in the public API (so uses can't add support for more map types).

The type of the map is optional and:

`MapLane<K, V> == MapLane<K, V, HashMap<K, V>>` 