### PR TITLE
Improves deserialization efficiency for agents.

### DIFF
--- a/server/swimos_agent/src/agent_model/mod.rs
+++ b/server/swimos_agent/src/agent_model/mod.rs
@@ -204,12 +204,12 @@ pub trait AgentDescription {
 /// although it will not provided any lifecycle events for the agent or its lanes.
 pub trait AgentSpec: AgentDescription + Sized + Send {
     /// The type of handler to run when a command is received for a value lane.
-    type ValCommandHandler<'a>: HandlerAction<Self, Completion = ()> + Send + 'static
+    type ValCommandHandler<'a>: HandlerAction<Self, Completion = ()> + Send + 'a
     where
         Self: 'a;
 
     /// The type of handler to run when a command is received for a map lane.
-    type MapCommandHandler<'a>: HandlerAction<Self, Completion = ()> + Send + 'static
+    type MapCommandHandler<'a>: HandlerAction<Self, Completion = ()> + Send + 'a
     where
         Self: 'a;
 

--- a/server/swimos_agent/src/agent_model/tests/external_links/empty_agent.rs
+++ b/server/swimos_agent/src/agent_model/tests/external_links/empty_agent.rs
@@ -37,19 +37,32 @@ impl AgentDescription for EmptyAgent {
 }
 
 impl AgentSpec for EmptyAgent {
-    type ValCommandHandler = UnitHandler;
+    type ValCommandHandler<'a> = UnitHandler
+    where
+        Self: 'a;
 
-    type MapCommandHandler = UnitHandler;
+    type MapCommandHandler<'a> = UnitHandler
+    where
+        Self: 'a;
 
     type OnSyncHandler = UnitHandler;
 
     type HttpRequestHandler = UnitHandler;
 
+    type Deserializers = ();
+
+    fn initializer_deserializers(&self) -> Self::Deserializers {}
+
     fn item_specs() -> HashMap<&'static str, ItemSpec> {
         HashMap::new()
     }
 
-    fn on_value_command(&self, _lane: &str, _body: BytesMut) -> Option<Self::ValCommandHandler> {
+    fn on_value_command(
+        &self,
+        _: &mut (),
+        _lane: &str,
+        _body: BytesMut,
+    ) -> Option<Self::ValCommandHandler<'_>> {
         None
     }
 
@@ -67,11 +80,12 @@ impl AgentSpec for EmptyAgent {
         None
     }
 
-    fn on_map_command(
+    fn on_map_command<'a>(
         &self,
+        _: &'a mut (),
         _lane: &str,
         _body: MapMessage<BytesMut, BytesMut>,
-    ) -> Option<Self::MapCommandHandler> {
+    ) -> Option<Self::MapCommandHandler<'a>> {
         None
     }
 

--- a/server/swimos_agent/src/agent_model/tests/fake_agent.rs
+++ b/server/swimos_agent/src/agent_model/tests/fake_agent.rs
@@ -168,9 +168,13 @@ impl AgentDescription for TestAgent {
 }
 
 impl AgentSpec for TestAgent {
-    type ValCommandHandler = TestHandler;
+    type ValCommandHandler<'a> = TestHandler
+    where
+        Self: 'a;
 
-    type MapCommandHandler = TestHandler;
+    type MapCommandHandler<'a> = TestHandler
+    where
+        Self: 'a;
 
     type OnSyncHandler = TestHandler;
 
@@ -219,7 +223,12 @@ impl AgentSpec for TestAgent {
         lanes
     }
 
-    fn on_value_command(&self, lane: &str, body: BytesMut) -> Option<Self::ValCommandHandler> {
+    fn on_value_command<'a>(
+        &self,
+        _: &'a mut (),
+        lane: &str,
+        body: BytesMut,
+    ) -> Option<Self::ValCommandHandler<'a>> {
         match lane {
             VAL_LANE => Some(
                 TestEvent::Value {
@@ -264,11 +273,12 @@ impl AgentSpec for TestAgent {
         None
     }
 
-    fn on_map_command(
+    fn on_map_command<'a>(
         &self,
+        _: &'a mut (),
         lane: &str,
         body: MapMessage<BytesMut, BytesMut>,
-    ) -> Option<Self::MapCommandHandler> {
+    ) -> Option<Self::MapCommandHandler<'a>> {
         match lane {
             MAP_LANE => Some(
                 TestEvent::Map {
@@ -426,6 +436,10 @@ impl AgentSpec for TestAgent {
             Err(DynamicRegistrationError::DuplicateName(name.to_string()))
         }
     }
+
+    type Deserializers = ();
+
+    fn initializer_deserializers(&self) -> Self::Deserializers {}
 }
 
 impl HandlerAction<TestAgent> for TestHandler {

--- a/server/swimos_agent/src/event_handler/mod.rs
+++ b/server/swimos_agent/src/event_handler/mod.rs
@@ -1342,11 +1342,11 @@ impl<Context, T: RecognizerReadable> HandlerAction<Context> for Decode<T> {
 
 pub struct DecodeRef<'a, T: RecognizerReadable> {
     decoder: Option<&'a mut RecognizerDecoder<T::Rec>>,
-    buffer: &'a mut BytesMut,
+    buffer: BytesMut,
 }
 
 impl<'a, T: RecognizerReadable> DecodeRef<'a, T> {
-    pub fn new(decoder: &'a mut RecognizerDecoder<T::Rec>, buffer: &'a mut BytesMut) -> Self {
+    pub fn new(decoder: &'a mut RecognizerDecoder<T::Rec>, buffer: BytesMut) -> Self {
         DecodeRef {
             decoder: Some(decoder),
             buffer,

--- a/server/swimos_agent_derive/src/lane_model_derive/mod.rs
+++ b/server/swimos_agent_derive/src/lane_model_derive/mod.rs
@@ -214,13 +214,23 @@ impl<'a> ToTokens for DeriveAgentLaneModel<'a> {
 
             #[automatically_derived]
             impl #root::agent_model::AgentSpec for #agent_type {
-                type ValCommandHandler = #value_handler;
+                type ValCommandHandler<'a> = #value_handler
+                where
+                    Self: 'a;
 
-                type MapCommandHandler = #map_handler;
+                type MapCommandHandler<'a> = #map_handler
+                where
+                    Self: 'a;
 
                 type OnSyncHandler = #sync_handler;
 
                 type HttpRequestHandler = #http_handler;
+
+                type Deserializers = ();
+
+                fn initializer_deserializers(&self) -> Self::Deserializers {
+
+                }
 
                 fn item_specs() -> ::std::collections::HashMap<&'static str, #root::agent_model::ItemSpec> {
                     let mut lanes = ::std::collections::HashMap::new();
@@ -228,18 +238,19 @@ impl<'a> ToTokens for DeriveAgentLaneModel<'a> {
                     lanes
                 }
 
-                fn on_value_command(&self, lane: &str, body: #root::reexport::bytes::BytesMut) -> ::core::option::Option<Self::ValCommandHandler> {
+                fn on_value_command<'a>(&self, deserializers: &'a mut Self::Deserializers, lane: &str, body: #root::reexport::bytes::BytesMut) -> ::core::option::Option<Self::ValCommandHandler<'a>> {
                     match lane {
                         #(#value_match_blocks,)*
                         _ => ::core::option::Option::None,
                     }
                 }
 
-                fn on_map_command(
+                fn on_map_command<'a>(
                     &self,
+                    deserializers: &'a mut Self::Deserializers,
                     lane: &str,
                     body: #root::model::MapMessage<#root::reexport::bytes::BytesMut, #root::reexport::bytes::BytesMut>,
-                ) -> ::core::option::Option<Self::MapCommandHandler> {
+                ) -> ::core::option::Option<Self::MapCommandHandler<'a>> {
                     match lane {
                         #(#map_match_blocks,)*
                         _ => ::core::option::Option::None,

--- a/server/swimos_connector/src/generic/tests.rs
+++ b/server/swimos_connector/src/generic/tests.rs
@@ -285,9 +285,10 @@ fn with_map_lane(agent: &ConnectorAgent, f: impl FnOnce(&GenericMapLane)) {
 #[test]
 fn value_lane_command() {
     let agent = ConnectorAgent::default();
+    let mut deserializers = agent.initializer_deserializers();
     let (val_id, _) = init(&agent);
     let handler = agent
-        .on_value_command("value_lane", to_buffer(Value::from(45)))
+        .on_value_command(&mut deserializers, "value_lane", to_buffer(Value::from(45)))
         .expect("No handler.");
     let ids = run_handler(&agent, handler);
     assert_eq!(ids, [val_id].into_iter().collect());
@@ -331,9 +332,11 @@ fn value_lane_sync() {
 #[test]
 fn map_lane_command() {
     let agent = ConnectorAgent::default();
+    let mut deserializers = agent.initializer_deserializers();
     let (_, map_id) = init(&agent);
     let handler = agent
         .on_map_command(
+            &mut deserializers,
             "map_lane",
             MapMessage::Update {
                 key: to_buffer(Value::text("a")),

--- a/swimos/tests/deriveagentlanemodel.rs
+++ b/swimos/tests/deriveagentlanemodel.rs
@@ -121,6 +121,7 @@ where
 {
     let agent = A::default();
     let expected = specs.into_iter().collect::<HashMap<_, _>>();
+    let mut deserializers = agent.initializer_deserializers();
 
     assert_eq!(A::item_specs(), expected);
 
@@ -130,17 +131,25 @@ where
         match descriptor {
             ItemDescriptor::WarpLane { kind, .. } => {
                 if kind.map_like() {
-                    assert!(agent.on_map_command(name, MapMessage::Clear).is_some());
+                    assert!(agent
+                        .on_map_command(&mut deserializers, name, MapMessage::Clear)
+                        .is_some());
                     assert!(agent.on_sync(name, SYNC_ID).is_some());
                 } else {
-                    assert!(agent.on_value_command(name, get_i32_buffer(4)).is_some());
+                    assert!(agent
+                        .on_value_command(&mut deserializers, name, get_i32_buffer(4))
+                        .is_some());
                     assert!(agent.on_sync(name, SYNC_ID).is_some());
                 }
             }
             ItemDescriptor::Store { .. } => {
-                assert!(agent.on_map_command(name, MapMessage::Clear).is_none());
+                assert!(agent
+                    .on_map_command(&mut deserializers, name, MapMessage::Clear)
+                    .is_none());
                 assert!(agent.on_sync(name, SYNC_ID).is_none());
-                assert!(agent.on_value_command(name, get_i32_buffer(4)).is_none());
+                assert!(agent
+                    .on_value_command(&mut deserializers, name, get_i32_buffer(4))
+                    .is_none());
                 assert!(agent.on_sync(name, SYNC_ID).is_none());
             }
             ItemDescriptor::Http => {


### PR DESCRIPTION
Agent implementations can now keep persistent deserializers for their lanes rather than recreating them each time.

The agents created by the derive macro have been updated to make use of this.